### PR TITLE
MVSNet Release/0.1.0 -- integration pt 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ dist/*
 MANIFEST
 MVSNet.egg-info/*
 .vscode/*
+wandb/*
 
 nohup.out

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ or vice versa.
 * Download the pre-trained MVSNet and R-MVSNet [models](https://drive.google.com/file/d/1h40Rq8ou5XLGFFSXTFBvrLla7-RMz73n/view) and upzip the file as ``MODEL_FOLDER``
 * Enter the ``MVSNet/mvsnet`` folder, in ``test.py``, set ``model_dir`` to ``MODEL_FOLDER``
 * Run MVSNet (GTX1080Ti): 
-``python test.py --dense_folder TEST_DATA_FOLDER  --regularization '3DCNNs' --max_w 1152 --max_h 864 --max_d 192 --interval_scale 1.06``
+``python test.py --dense_folder TEST_DATA_FOLDER  --regularization '3DCNNs' --width 1152 --height 864 --max_d 192 --interval_scale 1.06``
 * Run R-MVSNet (GTX1080Ti): 
-``python test.py --dense_folder TEST_DATA_FOLDER  --regularization 'GRU' --max_w 1600 --max_h 1200 --max_d 256 --interval_scale 0.8``
+``python test.py --dense_folder TEST_DATA_FOLDER  --regularization 'GRU' --width 1600 --height 1200 --max_d 256 --interval_scale 0.8``
 * Inspect the .pfm format outputs in ``TEST_DATA_FOLDER/depths_mvsnet`` using ``python visualize.py .pfm``. For example the depth map and probability map for image `00000012` should be something like:
 
 <img src="doc/image.png" width="250">   | <img src="doc/depth_example.png" width="250"> |  <img src="doc/probability_example.png" width="250">

--- a/mvsnet/cnn_wrapper/mvsnetworks.py
+++ b/mvsnet/cnn_wrapper/mvsnetworks.py
@@ -4,10 +4,10 @@ Copyright 2019, Yao Yao, HKUST.
 MVSNet sub-models.
 """
 
-from network import Network
+from mvsnet.cnn_wrapper.network import Network
 import sys
-sys.path.append('../')
-from MVSNet.mvsnet.utils import setup_logger
+#sys.path.append('../')
+from mvsnet.utils import setup_logger
 
 logger = setup_logger('mvsnet-networks')
 

--- a/mvsnet/cnn_wrapper/mvsnetworks.py
+++ b/mvsnet/cnn_wrapper/mvsnetworks.py
@@ -3,10 +3,8 @@
 Copyright 2019, Yao Yao, HKUST.
 MVSNet sub-models.
 """
-
-from mvsnet.cnn_wrapper.network import Network
 import sys
-#sys.path.append('../')
+from mvsnet.cnn_wrapper.network import Network
 from mvsnet.utils import setup_logger
 
 logger = setup_logger('mvsnet-networks')

--- a/mvsnet/cnn_wrapper/network.py
+++ b/mvsnet/cnn_wrapper/network.py
@@ -13,7 +13,7 @@ import sys
 import numpy as np
 import tensorflow as tf
 
-from common import Notify
+from mvsnet.cnn_wrapper.common import Notify
 
 DEFAULT_PADDING = 'SAME'
 

--- a/mvsnet/depthfusion.py
+++ b/mvsnet/depthfusion.py
@@ -22,7 +22,7 @@ import cv2
 import numpy as np
 
 import pylab as plt
-from preprocess import *
+from mvsnet.preprocess import *
 
 
 def read_gipuma_dmb(path):

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,9 +38,9 @@ tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 256,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 640,
+tf.app.flags.DEFINE_integer('width', 1024,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 480,
+tf.app.flags.DEFINE_integer('height', 768,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -14,7 +14,7 @@ import imageio
 import cv2
 import tensorflow as tf
 from mvsnet.loss import *
-from mvsnet.model import *
+from mvsnet.model import inference_mem, depth_refine, inference_winner_take_all
 from mvsnet.preprocess import *
 from mvsnet.cnn_wrapper.common import Notify
 from mvsnet.mvs_data_generation.cluster_generator import ClusterGenerator
@@ -70,6 +70,7 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
     """ Performs inference using trained MVSNet model on data located in input_dir """
     if width and height:
         FLAGS.width, FLAGS.height = width, height
+    logger.info('Computing depth maps with MVSNet. Using input width x height = {} x {}'.format(FLAGS.width,FLAGS.height))
 
     # create output folder
     if output_dir is None:

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -8,7 +8,6 @@ import sys
 import math
 import tensorflow as tf
 import numpy as np
-
 from mvsnet.cnn_wrapper.mvsnetworks import *
 from mvsnet.convgru import ConvGRUCell
 from mvsnet.homography_warping import *
@@ -151,8 +150,8 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_m
     # dynamic gpu params
     depth_end = depth_start + (tf.cast(depth_num, tf.float32) - 1) * depth_interval
     feature_c = 32
-    feature_h = FLAGS.max_h / 4
-    feature_w = FLAGS.max_w / 4
+    feature_h = FLAGS.height / 4
+    feature_w = FLAGS.width / 4
 
     # reference image
     ref_image = tf.squeeze(tf.slice(images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
@@ -283,7 +282,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
     gru1_filters = int(16 / base_divisor)
     gru2_filters = int(4 / base_divisor)
     gru3_filters = int(2 / base_divisor)
-    feature_shape = [FLAGS.batch_size, FLAGS.max_h/4, FLAGS.max_w/4, 32]
+    feature_shape = [FLAGS.batch_size, FLAGS.height/4, FLAGS.width/4, 32]
     gru_input_shape = [feature_shape[1], feature_shape[2]]
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])
     state2 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru2_filters])
@@ -371,7 +370,7 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
     gru2_filters = int(4 / base_divisor)
     gru3_filters = int(2 / base_divisor)
 
-    feature_shape = [FLAGS.batch_size, FLAGS.max_h/4, FLAGS.max_w/4, 32]
+    feature_shape = [FLAGS.batch_size, FLAGS.height/4, FLAGS.width/4, 32]
     gru_input_shape = [feature_shape[1], feature_shape[2]]
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])
     state2 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru2_filters])

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -9,9 +9,9 @@ import math
 import tensorflow as tf
 import numpy as np
 
-from cnn_wrapper.mvsnetworks import *
-from convgru import ConvGRUCell
-from homography_warping import *
+from mvsnet.cnn_wrapper.mvsnetworks import *
+from mvsnet.convgru import ConvGRUCell
+from mvsnet.homography_warping import *
 
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 import numpy as np
 
 from mvsnet.cnn_wrapper.mvsnetworks import *
-from mvsnet.convgru import ConvGRUCell
+#from mvsnet.convgru import ConvGRUCell
 from mvsnet.homography_warping import *
 
 FLAGS = tf.app.flags.FLAGS

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 import numpy as np
 
 from mvsnet.cnn_wrapper.mvsnetworks import *
-#from mvsnet.convgru import ConvGRUCell
+from mvsnet.convgru import ConvGRUCell
 from mvsnet.homography_warping import *
 
 FLAGS = tf.app.flags.FLAGS

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -65,6 +65,7 @@ class ClusterGenerator:
                 self.load_clusters(session_dir, clusters)
 
         self.logger.info(" There are {} clusters".format(len(clusters)))
+        self.logger.debug('Generating MVS clusters with width x height = {} x {}'.format(self.image_width,self.image_height))
         self.clusters = clusters
         return clusters
 

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -1,6 +1,7 @@
 import os
 from mvsnet.mvs_data_generation.mvs_cluster import Cluster
 import mvsnet.mvs_data_generation.utils as ut
+from mvsnet.utils import setup_logger
 import random
 import numpy as np
 import imageio
@@ -21,8 +22,9 @@ class ClusterGenerator:
                  interval_scale=1, base_image_size=1, include_empty=False, mode='training', val_split=0.1, rescaling=True, output_scale=0.25, flip_cams=True):
         # Setup logger
 
-        self.logger = logging.getLogger('ClusterGenerator')
-        ut.set_log_level(self.logger)
+        #self.logger = logging.getLogger('ClusterGenerator')
+       # ut.set_log_level(self.logger)
+        self.logger = setup_logger('ClusterGenerator')
         self.sessions_dir = sessions_dir
         self.view_num = view_num
         self.image_width = image_width

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -20,10 +20,6 @@ Copyright 2019, Chris Heinrich, Ubiquity6.
 class ClusterGenerator:
     def __init__(self, sessions_dir, view_num = 3, image_width=1024, image_height=768, depth_num=256,
                  interval_scale=1, base_image_size=1, include_empty=False, mode='training', val_split=0.1, rescaling=True, output_scale=0.25, flip_cams=True):
-        # Setup logger
-
-        #self.logger = logging.getLogger('ClusterGenerator')
-       # ut.set_log_level(self.logger)
         self.logger = setup_logger('ClusterGenerator')
         self.sessions_dir = sessions_dir
         self.view_num = view_num

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -1,6 +1,6 @@
 import os
 from mvsnet.mvs_data_generation.mvs_cluster import Cluster
-import utils as ut
+import mvsnet.mvs_data_generation.utils as ut
 import random
 import numpy as np
 import imageio

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -239,11 +239,4 @@ class ClusterGenerator:
                         'output cams shape: {}'.format(output_cams.shape))
                     self.logger.debug('image index: {}'.format(image_index))
 
-                    c_dir = os.path.join(
-                        self.sessions_dir, 'centered_images')
-                    ut.mkdir_p(c_dir)
-                    image_path = os.path.join(
-                        c_dir, '{}.jpg'.format(image_index))
-                    imageio.imsave(
-                        image_path, input_images[0].astype(np.uint8))
                     yield (output_images, input_images, output_cams, image_index)

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -1,5 +1,5 @@
 import os
-from mvs_cluster import Cluster
+from mvsnet.mvs_data_generation.mvs_cluster import Cluster
 import utils as ut
 import random
 import numpy as np

--- a/mvsnet/mvs_data_generation/mvs_cluster.py
+++ b/mvsnet/mvs_data_generation/mvs_cluster.py
@@ -1,5 +1,5 @@
 import numpy as np
-from utils import mask_depth_image, scale_camera, scale_image, center_image, set_log_level
+from mvsnet.mvs_data_generation.utils import mask_depth_image, scale_camera, scale_image, center_image, set_log_level
 import imageio
 import logging
 import json

--- a/mvsnet/mvs_data_generation/mvs_cluster.py
+++ b/mvsnet/mvs_data_generation/mvs_cluster.py
@@ -1,5 +1,6 @@
 import numpy as np
 from mvsnet.mvs_data_generation.utils import mask_depth_image, scale_camera, scale_image, center_image, set_log_level
+from mvsnet.utils import setup_logger
 import imageio
 import logging
 import json
@@ -32,8 +33,9 @@ class Cluster:
     def __init__(self, session_dir, ref_index, views, min_depth, max_depth, view_num,
                  image_width=1024, image_height=768, depth_num=256, interval_scale=1.0):
         logging.basicConfig()
-        self.logger = logging.getLogger('Cluster')
-        set_log_level(self.logger)
+        #self.logger = logging.getLogger('Cluster')
+        #set_log_level(self.logger)
+        self.logger = setup_logger('Cluster')
         self.session_dir = session_dir
         self.ref_index = int(ref_index)
         self.views = views

--- a/mvsnet/mvs_data_generation/mvs_cluster.py
+++ b/mvsnet/mvs_data_generation/mvs_cluster.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mvsnet.mvs_data_generation.utils import mask_depth_image, scale_camera, scale_image, center_image, set_log_level
+from mvsnet.mvs_data_generation.utils import mask_depth_image, scale_camera, scale_image, center_image
 from mvsnet.utils import setup_logger
 import imageio
 import logging
@@ -32,9 +32,6 @@ Copyright 2019, Chris Heinrich, Ubiquity6.
 class Cluster:
     def __init__(self, session_dir, ref_index, views, min_depth, max_depth, view_num,
                  image_width=1024, image_height=768, depth_num=256, interval_scale=1.0):
-        logging.basicConfig()
-        #self.logger = logging.getLogger('Cluster')
-        #set_log_level(self.logger)
         self.logger = setup_logger('Cluster')
         self.session_dir = session_dir
         self.ref_index = int(ref_index)

--- a/mvsnet/mvs_data_generation/utils.py
+++ b/mvsnet/mvs_data_generation/utils.py
@@ -16,6 +16,7 @@ import json
 from random import Random
 from tensorflow.python.lib.io import file_io
 import logging
+from mvsnet.utils import setup_logger
 
 
 """
@@ -45,10 +46,11 @@ def setup_logger(name):
     set_log_level(logger)
     return logger
 
-
+"""
 # Set up logger
 logger = logging.getLogger('data-generator-utils')
 set_log_level(logger)
+"""
 
 
 def center_image(img):

--- a/mvsnet/mvs_data_generation/utils.py
+++ b/mvsnet/mvs_data_generation/utils.py
@@ -30,29 +30,6 @@ Copyright 2019, Chris Heinrich, Ubiquity6.
 """
 
 
-
-
-
-def set_log_level(logger):
-    if 'LOG_LEVEL' in os.environ:
-        level = os.environ['LOG_LEVEL'].upper()
-        exec('logger.setLevel(logging.{})'.format(level))
-    else:
-        logger.setLevel(logging.INFO)
-
-def setup_logger(name):
-    logging.basicConfig()
-    logger = logging.getLogger(name)
-    set_log_level(logger)
-    return logger
-
-"""
-# Set up logger
-logger = logging.getLogger('data-generator-utils')
-set_log_level(logger)
-"""
-
-
 def center_image(img):
     """ normalize image input """
     img = img.astype(np.float32)

--- a/mvsnet/mvs_data_generation/utils.py
+++ b/mvsnet/mvs_data_generation/utils.py
@@ -113,7 +113,7 @@ def scale_mvs_input(images, cams, depth_image=None, scale=1):
         return images, cams, depth_image
 
 
-def crop_mvs_input(images, cams, max_w, max_h, base_image_size, depth_image=None):
+def crop_mvs_input(images, cams, width, height, base_image_size, depth_image=None):
     """ resize images and cameras to fit the network (so both dimensions are divisible by base_image_size ) """
 
     # crop images and cameras
@@ -121,13 +121,13 @@ def crop_mvs_input(images, cams, max_w, max_h, base_image_size, depth_image=None
         h, w = images[view].shape[0:2]
         new_h = h
         new_w = w
-        if new_h > max_h:
-            new_h = max_h
+        if new_h > height:
+            new_h = height
         else:
             new_h = int(math.ceil(h / base_image_size)
                         * base_image_size)
-        if new_w > max_w:
-            new_w = max_w
+        if new_w > width:
+            new_w = width
         else:
             new_w = int(math.ceil(w / base_image_size)
                         * base_image_size)

--- a/mvsnet/preprocess.py
+++ b/mvsnet/preprocess.py
@@ -74,12 +74,12 @@ def crop_mvs_input(images, cams, depth_image=None):
         h, w = images[view].shape[0:2]
         new_h = h
         new_w = w
-        if new_h > FLAGS.max_h:
-            new_h = FLAGS.max_h
+        if new_h > FLAGS.height:
+            new_h = FLAGS.height
         else:
             new_h = int(math.ceil(h / FLAGS.base_image_size) * FLAGS.base_image_size)
-        if new_w > FLAGS.max_w:
-            new_w = FLAGS.max_w
+        if new_w > FLAGS.width:
+            new_w = FLAGS.width
         else:
             new_w = int(math.ceil(w / FLAGS.base_image_size) * FLAGS.base_image_size)
         start_h = int(math.ceil((h - new_h) / 2))

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -69,7 +69,7 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 FLAGS = tf.app.flags.FLAGS
 
 
-def mvsnet_test(test_folder, mvs_list=None):
+def compute_depth_maps(test_folder, mvs_list=None):
     """ Performs inference using trained MVSNet model on data located in test_folder0 """
 
     # create output folder
@@ -217,11 +217,11 @@ def main(_):  # pylint: disable=unused-argument
     # Acceptable input for the dense_folder is a single test folder, or a folder containing multiple
     # test folders. We check to see which one it is
     if os.path.isfile(os.path.join(FLAGS.dense_folder, 'covisibility.json')):
-        mvsnet_test(FLAGS.dense_folder)
+        compute_depth_maps(FLAGS.dense_folder)
     else:
         folders = os.listdir(FLAGS.dense_folder)
         for f in folders:
-            mvsnet_test(os.path.join(FLAGS.dense_folder, f))
+            compute_depth_maps(os.path.join(FLAGS.dense_folder, f))
 
 
 if __name__ == '__main__':

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -1,18 +1,9 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-from mvsnet.loss import *
-from mvsnet.model import *
-from mvsnet.preprocess import *
-from mvsnet.cnn_wrapper.common import Notify
-from mvsnet.mvs_data_generation.cluster_generator import ClusterGenerator
-from mvsnet.utils import setup_logger
 """
 Copyright 2019, Yao Yao, HKUST.
 Test script.
 """
-
-
+from __future__ import print_function
 import os
 import time
 import sys
@@ -22,28 +13,32 @@ import numpy as np
 import imageio
 import cv2
 import tensorflow as tf
+from mvsnet.loss import *
+from mvsnet.model import *
+from mvsnet.preprocess import *
+from mvsnet.cnn_wrapper.common import Notify
+from mvsnet.mvs_data_generation.cluster_generator import ClusterGenerator
+import mvsnet.utils as mu
 
-
-logger = setup_logger('mvsnet-test')
-
+logger = mu.setup_logger('mvsnet-inference')
 sys.path.append("../")
 
 # dataset parameters
 tf.app.flags.DEFINE_string('dense_folder', None,
                            """Root path to dense folder.""")
 tf.app.flags.DEFINE_string('model_dir',
-                           'gs://mvs-training-mlengine/all_data_fixed_fromscratch_15epochs/models/',
+                           'gs://mvs-training-mlengine/trained-models/06-04-2019/',
                            """Path to restore the model.""")
-tf.app.flags.DEFINE_integer('ckpt_step', 20000,
+tf.app.flags.DEFINE_integer('ckpt_step', 1350000,
                             """ckpt  step.""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 4,
+tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 128,
+tf.app.flags.DEFINE_integer('max_d', 256,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('max_w', 1024,
+tf.app.flags.DEFINE_integer('max_w', 640,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('max_h', 768,
+tf.app.flags.DEFINE_integer('max_h', 480,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -69,16 +64,18 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 FLAGS = tf.app.flags.FLAGS
 
 
-def compute_depth_maps(test_folder):
-    """ Performs inference using trained MVSNet model on data located in test_folder0 """
+def compute_depth_maps(input_dir, output_dir = None, width = None, height = None):
+    """ Performs inference using trained MVSNet model on data located in input_dir """
+    if width and height:
+        FLAGS.max_w, FLAGS.max_h = width, height
 
     # create output folder
-    output_folder = os.path.join(test_folder, 'depths_mvsnet')
-    if not os.path.isdir(output_folder):
-        os.mkdir(output_folder)
+    if output_dir is None:
+        output_dir = os.path.join(input_dir, 'depths_mvsnet')
+    mu.mkdir_p(output_dir)
 
     # testing set
-    data_gen = ClusterGenerator(test_folder, FLAGS.view_num, FLAGS.max_w, FLAGS.max_h,
+    data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.max_w, FLAGS.max_h,
                                 FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='test')
     mvs_generator = iter(data_gen)
     sample_size = len(data_gen.train_clusters)
@@ -131,13 +128,8 @@ def compute_depth_maps(test_folder):
                                                              depth_num, depth_start, depth_end, network_mode=FLAGS.network_mode, reg_type='GRU', inverse_depth=FLAGS.inverse_depth)
 
     # init option
-    init_op = tf.global_variables_initializer()
     var_init_op = tf.local_variables_initializer()
-
-    # GPU grows incrementally
-    config = tf.ConfigProto()
-    config.gpu_options.allow_growth = True
-    config.intra_op_parallelism_threads = 1
+    init_op, config = mu.init_session()
 
     with tf.Session(config=config) as sess:
 
@@ -183,18 +175,18 @@ def compute_depth_maps(test_folder):
 
             # paths
             init_depth_map_path = os.path.join(
-                output_folder, '{}_init.pfm'.format(out_index))
+                output_dir, '{}_init.pfm'.format(out_index))
             prob_map_path = os.path.join(
-                output_folder, '{}_prob.pfm'.format(out_index))
+                output_dir, '{}_prob.pfm'.format(out_index))
             out_ref_image_path = os.path.join(
-                output_folder, '{}.jpg'.format(out_index))
+                output_dir, '{}.jpg'.format(out_index))
             out_ref_cam_path = os.path.join(
-                output_folder, '{}.txt'.format(out_index))
+                output_dir, '{}.txt'.format(out_index))
             # png outputs
             prob_png = os.path.join(
-                output_folder, '{}_prob.png'.format(out_index))
+                output_dir, '{}_prob.png'.format(out_index))
             depth_png = os.path.join(
-                output_folder, '{}_depth.png'.format(out_index))
+                output_dir, '{}_depth.png'.format(out_index))
 
             # save output
             write_pfm(init_depth_map_path, out_init_depth_image)
@@ -213,9 +205,11 @@ def compute_depth_maps(test_folder):
 
 
 def main(_):  # pylint: disable=unused-argument
-    """ program entrance """
-    # Acceptable input for the dense_folder is a single test folder, or a folder containing multiple
-    # test folders. We check to see which one it is
+    """
+    Program entrance for running inference with MVSNet
+    Acceptable input for the dense_folder are (1) a single test folder, or (2) a folder containing multiple
+    test folders. We check to see which one it is
+    """
     if os.path.isfile(os.path.join(FLAGS.dense_folder, 'covisibility.json')):
         compute_depth_maps(FLAGS.dense_folder)
     else:

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -19,9 +19,11 @@ import math
 import argparse
 import numpy as np
 import imageio
-
 import cv2
 import tensorflow as tf
+from utils import setup_logger
+
+logger = setup_logger('mvsnet-test')
 
 sys.path.append("../")
 
@@ -66,8 +68,8 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 FLAGS = tf.app.flags.FLAGS
 
 
-def mvsnet_pipeline(test_folder, mvs_list=None):
-    """ mvsnet in altizure pipeline """
+def mvsnet_test(test_folder, mvs_list=None):
+    """ Performs inference using trained MVSNet model on data located in test_folder0 """
 
     # create output folder
     output_folder = os.path.join(test_folder, 'depths_mvsnet')
@@ -214,11 +216,11 @@ def main(_):  # pylint: disable=unused-argument
     # Acceptable input for the dense_folder is a single test folder, or a folder containing multiple
     # test folders. We check to see which one it is
     if os.path.isfile(os.path.join(FLAGS.dense_folder, 'covisibility.json')):
-        mvsnet_pipeline(FLAGS.dense_folder)
+        mvsnet_test(FLAGS.dense_folder)
     else:
         folders = os.listdir(FLAGS.dense_folder)
         for f in folders:
-            mvsnet_pipeline(os.path.join(FLAGS.dense_folder, f))
+            mvsnet_test(os.path.join(FLAGS.dense_folder, f))
 
 
 if __name__ == '__main__':

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -69,7 +69,7 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 FLAGS = tf.app.flags.FLAGS
 
 
-def compute_depth_maps(test_folder, mvs_list=None):
+def compute_depth_maps(test_folder):
     """ Performs inference using trained MVSNet model on data located in test_folder0 """
 
     # create output folder

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from loss import *
-from model import *
-from preprocess import *
-from cnn_wrapper.common import Notify
-from mvs_data_generation.cluster_generator import ClusterGenerator
+from mvsnet.loss import *
+from mvsnet.model import *
+from mvsnet.preprocess import *
+from mvsnet.cnn_wrapper.common import Notify
+from mvsnet.mvs_data_generation.cluster_generator import ClusterGenerator
+from mvsnet.utils import setup_logger
 """
 Copyright 2019, Yao Yao, HKUST.
 Test script.
@@ -21,7 +22,7 @@ import numpy as np
 import imageio
 import cv2
 import tensorflow as tf
-from utils import setup_logger
+
 
 logger = setup_logger('mvsnet-test')
 

--- a/mvsnet/test.py
+++ b/mvsnet/test.py
@@ -32,9 +32,9 @@ sys.path.append("../")
 tf.app.flags.DEFINE_string('dense_folder', None,
                            """Root path to dense folder.""")
 tf.app.flags.DEFINE_string('model_dir',
-                           None,
+                           'gs://mvs-training-mlengine/all_data_fixed_fromscratch_15epochs/models/',
                            """Path to restore the model.""")
-tf.app.flags.DEFINE_integer('ckpt_step', None,
+tf.app.flags.DEFINE_integer('ckpt_step', 20000,
                             """ckpt  step.""")
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 4,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
-tf.app.flags.DEFINE_integer('max_w', 640,
+tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
-tf.app.flags.DEFINE_integer('max_h', 480,
+tf.app.flags.DEFINE_integer('height', 480,
                             """Maximum image height when training.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume.""")
@@ -150,7 +150,7 @@ def generator(n, mode):
     flip_cams = False
     if FLAGS.regularization == 'GRU':
         flip_cams = True
-    gen = ClusterGenerator(FLAGS.train_data_root, FLAGS.view_num, FLAGS.max_w, FLAGS.max_h,
+    gen = ClusterGenerator(FLAGS.train_data_root, FLAGS.view_num, FLAGS.width, FLAGS.height,
                                 FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode=mode, flip_cams=flip_cams)
     logger.info('Initializing generator with mode {}'.format(mode))
     if mode == 'training':

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-from homography_warping import get_homographies, homography_warping
-from model import *
-from preprocess import *
-from loss import *
-from cnn_wrapper.common import Notify
-from mvs_data_generation.cluster_generator import ClusterGenerator
+from mvsnet.homography_warping import get_homographies, homography_warping
+from mvsnet.model import *
+from mvsnet.preprocess import *
+from mvsnet.loss import *
+from mvsnet.cnn_wrapper.common import Notify
+from mvsnet.mvs_data_generation.cluster_generator import ClusterGenerator
+import mvsnet.utils as mu
 """
 Copyright 2019, Yao Yao, HKUST.
 Training script.
@@ -20,12 +21,12 @@ import argparse
 from random import randint
 import cv2
 import numpy as np
+import wandb
 import tensorflow as tf
 from tensorflow.python.lib.io import file_io
-from utils import setup_logger
 
-logger = setup_logger('mvsnet-train')
 
+logger = mu.setup_logger('mvsnet-train')
 
 # params for datasets
 tf.app.flags.DEFINE_string('train_data_root', None,
@@ -48,7 +49,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('max_w', 640,
                             """Maximum image width when training.""")
@@ -78,7 +79,7 @@ tf.app.flags.DEFINE_integer('epoch', None,
                             """Training epoch number.""")
 tf.app.flags.DEFINE_float('val_ratio', 0,
                           """Ratio of validation set when splitting dataset.""")
-tf.app.flags.DEFINE_float('base_lr', 0.000025,
+tf.app.flags.DEFINE_float('base_lr', 0.001,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
@@ -106,16 +107,6 @@ def load_model(total_step):
         print(Notify.INFO, 'Pre-trained model restored from %s' %
                 ('-'.join([pretrained_model_path, str(FLAGS.ckpt_step)])), Notify.ENDC)
         total_step = FLAGS.ckpt_step
-
-def init_session():
-    """ Returns tf global vars initializer and sets the config """
-    init_op = tf.global_variables_initializer()
-    config = tf.ConfigProto(allow_soft_placement=True)
-    config.gpu_options.allow_growth = True
-    config.inter_op_parallelism_threads = 0
-    config.intra_op_parallelism_threads = 0
-    return init_op, config
-
 
 def average_gradients(tower_grads):
     """Calculate the average gradient for each shared variable across all towers.
@@ -389,7 +380,7 @@ def train():
         grads = average_gradients(tower_grads)
         train_opt = opt.apply_gradients(grads, global_step=global_step)
         saver = tf.train.Saver(tf.global_variables(), max_to_keep=None)
-        init_op, config = init_session()
+        init_op, config = mu.init_session()
 
         with tf.Session(config=config) as sess:
             # initialization

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -24,7 +24,7 @@ import tensorflow as tf
 from tensorflow.python.lib.io import file_io
 from utils import setup_logger
 
-logger = setup_logger('train')
+logger = setup_logger('mvsnet-train')
 
 
 # params for datasets
@@ -247,6 +247,7 @@ def initialize_trainer():
     logger.info("Training starting at time: {}".format(train_session_start))
     logger.info("Tensorflow version: {}".format(tf.__version__))
     logger.info("Flags: {}".format(FLAGS))
+    os.system('wandb login 08b2fe7c6c5d56f49b9c2dee8f24ca14c0679509') # Login to wandb
 
     # Prepare validation summary 
     val_sum_file = os.path.join(

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -248,6 +248,7 @@ def initialize_trainer():
     logger.info("Tensorflow version: {}".format(tf.__version__))
     logger.info("Flags: {}".format(FLAGS))
     os.system('wandb login 08b2fe7c6c5d56f49b9c2dee8f24ca14c0679509') # Login to wandb
+    wandb.init()
 
     # Prepare validation summary 
     val_sum_file = os.path.join(

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -8,10 +8,10 @@ A small library of helper functions sued through the mvsnet package
 
 def set_log_level(logger):
     """ Grabs log level from command line """
-    if 'LOG_LEVEL' in os.environ:
+    try:
         level = os.environ['LOG_LEVEL'].upper()
         exec('logger.setLevel(logging.{})'.format(level))
-    else:
+    except Exception as e:
         logger.setLevel(logging.INFO)
 
 def setup_logger(name):

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -1,8 +1,13 @@
-import logging 
+import logging
+import tensorflow as tf 
 import os
 
+"""
+A small library of helper functions sued through the mvsnet package 
+"""
 
 def set_log_level(logger):
+    """ Grabs log level from command line """
     if 'LOG_LEVEL' in os.environ:
         level = os.environ['LOG_LEVEL'].upper()
         exec('logger.setLevel(logging.{})'.format(level))
@@ -10,7 +15,23 @@ def set_log_level(logger):
         logger.setLevel(logging.INFO)
 
 def setup_logger(name):
+    """ Sets up a logger, grabbing log_level from command line """
     logging.basicConfig()
     logger = logging.getLogger(name)
     set_log_level(logger)
     return logger
+
+    
+def init_session():
+    """ Returns tf global vars initializer and sets the config """
+    init_op = tf.global_variables_initializer()
+    config = tf.ConfigProto(allow_soft_placement=True)
+    config.gpu_options.allow_growth = True
+    config.inter_op_parallelism_threads = 0
+    config.intra_op_parallelism_threads = 0
+    return init_op, config
+
+def mkdir_p(dir_path):
+    """ Makes the directory dir_path if it doesn't exist """
+    if not os.path.isdir(dir_path):
+        os.mkdir(dir_path)

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -18,7 +18,11 @@ def setup_logger(name):
     """ Sets up a logger, grabbing log_level from command line """
     logging.basicConfig()
     logger = logging.getLogger(name)
-    set_log_level(logger)
+    try:
+        set_log_level(logger)
+    except Exception as e:
+        logger.setLevel(logging.INFO)
+        logger.warn('Failed to set log level with exception {}'.format(e))
     return logger
 
     

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,7 +11,7 @@ def run(args):
 
 
 def test(dense_folder, ckpt_step, model_dir):
-    args = ["python", "-m", "mvsnet.test", "--dense_folder",
+    args = ["python", "-m", "mvsnet.inference", "--input_dir",
             dense_folder, "--ckpt_step", ckpt_step, "--model_dir", model_dir]
     run(args)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     name=NAME,
     version=VERSION,
     #packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
-    packages=find_packages(),
+    packages=find_packages(exclude=['datasets*','scripts*']),
     install_requires=required_packages(),
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # Package Metadata
 
-NAME='MVSNet-test1'
+NAME='MVSNet'
 VERSION='0.4.0'
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ def required_packages():
         'Pillow>=3.1.2',
         'imageio',
         'wandb',
-        'tensorflow==1.13.0',
-        'tensorflow-estimator==1.13.0',
+        'tensorflow==1.12.0',
+        'tensorflow-estimator==1.12.0',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ def required_packages():
         'Pillow>=3.1.2',
         'imageio',
         'wandb',
-        'tensorflow==1.12.0',
-        'tensorflow-estimator==1.12.0',
+        'tensorflow==1.13.1',
+        'tensorflow-estimator==1.13.0',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 from distutils.core import setup
 from setuptools import find_packages
 
+# Package Metadata
+
+NAME='MVSNet'
+VERSION='0.4.0'
+
+
+
 
 def required_packages():
     # place dependencies here
@@ -18,9 +25,10 @@ def required_packages():
     return PACKAGES
 
 setup(
-    name='MVSNet',
-    version='0.3dev',
-    packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
+    name=NAME,
+    version=VERSION,
+    #packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
+    packages=find_packages(),
     install_requires=required_packages(),
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 # Package Metadata
 
 NAME='MVSNet'
-VERSION='0.4.0'
+VERSION='0.1.0'
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,10 @@ from distutils.core import setup
 from setuptools import find_packages
 
 # Package Metadata
-
 NAME='MVSNet'
 VERSION='0.1.0'
 
-
-
-
 def required_packages():
-    # place dependencies here
     PACKAGES = [
         'progressbar2>=3.0',
         'numpy>=1.13',
@@ -29,7 +24,6 @@ def required_packages():
 setup(
     name=NAME,
     version=VERSION,
-    #packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
     packages=find_packages(exclude=['datasets*','scripts*']),
     install_requires=required_packages(),
     license='Creative Commons Attribution-Noncommercial-Share Alike license',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 
 def required_packages():
-    # place dependencies that don't care about GPU vs CPU here
+    # place dependencies here
     PACKAGES = [
         'progressbar2>=3.0',
         'numpy>=1.13',
@@ -12,7 +12,8 @@ def required_packages():
         'scipy>=0.18',
         'matplotlib>=1.5',
         'Pillow>=3.1.2',
-        'imageio'
+        'imageio',
+        'wandb',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ def required_packages():
         'Pillow>=3.1.2',
         'imageio',
         'wandb',
+        'tensorflow>=1.13.1'
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ def required_packages():
         'Pillow>=3.1.2',
         'imageio',
         'wandb',
-        'tensorflow>=1.13.0'
+        'tensorflow==1.13.0',
+        'tensorflow-estimator==1.13.0',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def required_packages():
         'imageio',
         'wandb',
         'tensorflow==1.13.1',
-        'tensorflow-estimator==1.13.0',
+        'tensorflow-estimator==1.10.12',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # Package Metadata
 
-NAME='MVSNet'
+NAME='MVSNet-test1'
 VERSION='0.4.0'
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def required_packages():
         'Pillow>=3.1.2',
         'imageio',
         'wandb',
-        'tensorflow>=1.13.1'
+        'tensorflow>=1.13.0'
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ def required_packages():
 setup(
     name=NAME,
     version=VERSION,
-    #packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
-    packages=find_packages(),
+    packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
+    #packages=find_packages(),
     install_requires=required_packages(),
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ def required_packages():
 setup(
     name=NAME,
     version=VERSION,
-    packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
-    #packages=find_packages(),
+    #packages=['mvsnet', 'mvsnet/cnn_wrapper','mvsnet/mvs_data_generation'],
+    packages=find_packages(),
     install_requires=required_packages(),
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.md').read(),


### PR DESCRIPTION
This PR rewires import statements and updates setup.py so that MVSNet can be easily installed and run with pip. To install this branch you would run
```
pip install git+https://github.com/ubiquity6/MVSNet@release/0.1.0
```
It also includes some updates to the inference script. In particular, `mvsnet_pipeline` has been changed to `compute_depth_maps` and the interface has been updated so there is more flexibility when this function is imported elsewhere.

Note that there is still some cleanup work left to do in the test.py script, and repo in general, and I have another Jira ticket to track that work. However I don't expect the interface to change for the compute_depth_maps function so we can be free to use this elsewhere