### PR TITLE
MVSNet improvements part 1 -- tiered training of refinement network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ MANIFEST
 MVSNet.egg-info/*
 .vscode/*
 wandb/*
+scratch/*
 
 nohup.out

--- a/mvsnet/cnn_wrapper/mvsnet.py
+++ b/mvsnet/cnn_wrapper/mvsnet.py
@@ -8,7 +8,7 @@ from network import Network
 
 
 ########################################################################################
-############################# 2D feature extraction nework #############################
+############################# 2D feature extraction network #############################
 ########################################################################################
 
 class UniNetDS2(Network):
@@ -164,5 +164,10 @@ class RefineNet(Network):
          .conv_bn(3, 32, 1, name='refine_conv2')
          .conv(3, 1, 1, relu=False, name='refine_conv3'))
 
-        (self.feed('refine_conv3', 'depth_image')
-         .add(name='refined_depth_image'))
+        # (CH) I am experimenting with adding the residual to the 
+        # original depth estimate, rather than adding to normalized depth estimate
+        # followed by the denormalizing scaling. I think this is a good idea because the previous
+        # way of doing things constrained the output of refine_conv3 to only take on very small values
+        # which would lead to small gradients
+        #(self.feed('refine_conv3', 'depth_image')
+        # .add(name='refined_depth_image'))

--- a/mvsnet/cnn_wrapper/network.py
+++ b/mvsnet/cnn_wrapper/network.py
@@ -51,17 +51,17 @@ def layer(op):
 class Network(object):
     """Class NetWork."""
 
-    def __init__(self, inputs, is_training, mode='normal',
+    def __init__(self, inputs, trainable, training=True, mode='normal',
                  dropout_rate=0.5, seed=None, epsilon=1e-5, reuse=False, fcn=True, regularize=True,
                  **kwargs):
         # The input nodes for this network
         self.inputs = inputs
         # If true, the resulting variables are set as trainable
-        self.trainable = is_training if isinstance(is_training, bool) else True
+        self.trainable = trainable if isinstance(trainable, bool) else True
         # If true, variables are shared between feature towers
         self.reuse = reuse
-        # If true, layers like batch normalization or dropout are working in training mode
-        self.training = is_training
+        #  Should be True for training mode and false for inference
+        self.training = training
         # Dropout rate
         self.dropout_rate = dropout_rate
         # Seed for randomness
@@ -71,7 +71,11 @@ class Network(object):
         # The epsilon paramater in BN layer.
         self.bn_epsilon = epsilon
         self.extra_args = kwargs
-        self.base_divisor = 1 if mode == 'normal' else 2 # for dividing the base_filter size of the network
+        self.base_divisor = 1  # for dividing the base_filter size of the network
+        if mode == 'lite':
+            self.base_divisor = 2
+        if mode == 'ultralite':
+            self.base_divisor = 4
         if inputs is not None:
             # The current list of terminal nodes
             self.terminals = []

--- a/mvsnet/convgru.py
+++ b/mvsnet/convgru.py
@@ -90,7 +90,7 @@ class ConvGRUCell(tf.contrib.rnn.RNNCell):
 
                 # convolution
                 conv = tf.layers.conv2d(
-                    inputs, 2 * self._filters, self._kernel, padding='same', name='conv')
+                    inputs, 2 * self._filters, self._kernel, padding='same', name='conv', trainable=self.trainable)
                 reset_gate, update_gate = tf.split(conv, 2, axis=self._feature_axis)
 
                 # group normalization, actually is 'instance normalization' as to save GPU memory 
@@ -108,7 +108,7 @@ class ConvGRUCell(tf.contrib.rnn.RNNCell):
 
                 # convolution
                 conv = tf.layers.conv2d(
-                    inputs, self._filters, self._kernel, padding='same', name='output_conv')
+                    inputs, self._filters, self._kernel, padding='same', name='output_conv', trainable=self.trainable)
 
                 # group normalization
                 conv = group_norm(conv, 'output_norm', group_channel=16)

--- a/mvsnet/convgru.py
+++ b/mvsnet/convgru.py
@@ -60,7 +60,8 @@ class ConvGRUCell(tf.contrib.rnn.RNNCell):
                  kernel,
                  initializer=None,
                  activation=tf.tanh,
-                 normalize=True):
+                 normalize=True,
+                 trainable=True):
         self._filters = filters
         self._kernel = kernel
         self._initializer = initializer
@@ -68,6 +69,7 @@ class ConvGRUCell(tf.contrib.rnn.RNNCell):
         self._size = tf.TensorShape(shape + [self._filters])
         self._normalize = normalize
         self._feature_axis = self._size.ndims
+        self.trainable=trainable
 
     @property
     def state_size(self):

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -60,8 +60,8 @@ tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for MVSNet""")
 tf.app.flags.DEFINE_bool('inverse_depth', True,
                          """Whether to apply inverse depth for R-MVSNet""")
-tf.app.flags.DEFINE_string('network_mode', 'normal',
-                            """One of 'normal' or 'lite'. If 'lite' then networks have fewer params""")
+tf.app.flags.DEFINE_string('network_mode', 'ultralite',
+                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
 
 FLAGS = tf.app.flags.FLAGS
 
@@ -117,18 +117,18 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
     # depth map inference using 3DCNNs
     if FLAGS.regularization == '3DCNNs':
         init_depth_map, prob_map = inference_mem(
-            centered_images, scaled_cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode)
+            centered_images, scaled_cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, training=False)
 
         if FLAGS.refinement:
             ref_image = tf.squeeze(
                 tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(
-                init_depth_map, ref_image, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, True)
+                init_depth_map, ref_image, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, True, training=False)
 
     # depth map inference using GRU
     elif FLAGS.regularization == 'GRU':
         init_depth_map, prob_map = inference_winner_take_all(centered_images, scaled_cams,
-                                                             depth_num, depth_start, depth_end, network_mode=FLAGS.network_mode, reg_type='GRU', inverse_depth=FLAGS.inverse_depth)
+                                                             depth_num, depth_start, depth_end, network_mode=FLAGS.network_mode, reg_type='GRU', inverse_depth=FLAGS.inverse_depth, training=False)
 
     # init option
     var_init_op = tf.local_variables_initializer()

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -488,6 +488,12 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
     norm_depth_map = norm_depth_tower.get_output()
 
     # denormalize depth map
-    refined_depth_map = tf.multiply(norm_depth_map, depth_scale_mat) + depth_start_mat
+    # (CH) I am experimenting with adding the residual to the 
+    # original depth estimate, rather than adding to normalized depth estimate
+    # followed by the denormalizing scaling. I think this is a good idea because the previous
+    # way of doing things constrained the output of refine_conv3 to only take on very small values
+    # which would lead to small gradients
+    #refined_depth_map = tf.multiply(norm_depth_map, depth_scale_mat) + depth_start_mat
+    refined_depth_map = tf.add_n((norm_depth_map, init_depth_map),name='add_residual')
 
     return refined_depth_map

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -67,7 +67,7 @@ def get_propability_map(cv, depth_map, depth_start, depth_interval):
 
     return prob_map
 
-def inference(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True):
+def inference(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, trainable=True):
     """ infer depth image from multi-view images and cameras """
 
     # dynamic gpu params
@@ -79,13 +79,13 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, mode=network_mode, reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, trainable=True, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -118,9 +118,9 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     # filtered cost volume, size of (B, D, H, W, 1)
     if is_master_gpu:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, mode=network_mode, reuse=False)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=trainable, mode=network_mode, reuse=False)
     else:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, mode=network_mode, reuse=True)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=trainable, mode=network_mode, reuse=True)
     filtered_cost_volume = tf.squeeze(filtered_cost_volume_tower.get_output(), axis=-1)
 
     # depth map by softArgmin
@@ -144,7 +144,7 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     return estimated_depth_map, prob_map#, filtered_depth_map, probability_volume
 
-def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True):
+def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True, trainable=True):
     """ inference of depth image from multi-view images and cameras """
 
     # dynamic gpu params
@@ -159,16 +159,16 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, training=training, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, training=training, mode=network_mode, reuse=True)
     ref_feature = ref_tower.get_output()
     ref_feature2 = tf.square(ref_feature)
 
     view_features = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, trainable=True, training=training, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, training=training, mode=network_mode, reuse=True)
         view_features.append(view_tower.get_output())
     view_features = tf.stack(view_features, axis=0)
 
@@ -219,9 +219,9 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
 
     # filtered cost volume, size of (B, D, H, W, 1)
     if is_master_gpu:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, training=training, mode=network_mode, reuse=False)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=trainable, training=training, mode=network_mode, reuse=False)
     else:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, training=training, mode=network_mode,  reuse=True)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=trainable, training=training, mode=network_mode,  reuse=True)
     filtered_cost_volume = tf.squeeze(filtered_cost_volume_tower.get_output(), axis=-1)
 
     # depth map by softArgmin
@@ -247,7 +247,7 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
     return estimated_depth_map, prob_map
 
 
-def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True):
+def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, trainable=True):
     """ infer disparity image from stereo images and cameras """
 
     # dynamic gpu params
@@ -259,13 +259,13 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, mode=network_mode, reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, trainable=True, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -329,7 +329,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
     return prob_volume
 
 def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, network_mode,
-                              is_master_gpu=True, reg_type='GRU', inverse_depth=False, training=True):
+                              is_master_gpu=True, reg_type='GRU', inverse_depth=False, training=True, trainable=True):
     """ infer disparity image from stereo images and cameras """
 
     if not inverse_depth:
@@ -341,13 +341,13 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, training=training, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode,  reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable, training=training, mode=network_mode,  reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, trainable=True, training=training, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, training=training, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -462,7 +462,7 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
     forward_depth_map = depth_image
     return forward_depth_map, max_prob_image / forward_exp_sum
 
-def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True):
+def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True, trainable=True):
     """ refine depth image with the image """
 
     # normalization parameters
@@ -483,10 +483,10 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
     # refinement network
     if is_master_gpu:
         norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
-                                        trainable=True, training=training, mode=network_mode, reuse=False)
+                                        trainable=trainable, training=training, mode=network_mode, reuse=False)
     else:
         norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
-                                        trainable=True, training=training, mode=network_mode, reuse=True)
+                                        trainable=trainable, training=training, mode=network_mode, reuse=True)
     norm_depth_map = norm_depth_tower.get_output()
 
     # denormalize depth map

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -79,13 +79,13 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=True, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -118,9 +118,9 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     # filtered cost volume, size of (B, D, H, W, 1)
     if is_master_gpu:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode, reuse=False)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, mode=network_mode, reuse=False)
     else:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode, reuse=True)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, mode=network_mode, reuse=True)
     filtered_cost_volume = tf.squeeze(filtered_cost_volume_tower.get_output(), axis=-1)
 
     # depth map by softArgmin
@@ -144,8 +144,8 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     return estimated_depth_map, prob_map#, filtered_depth_map, probability_volume
 
-def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_mode, is_master_gpu=True):
-    """ infer depth image from multi-view images and cameras """
+def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True):
+    """ inference of depth image from multi-view images and cameras """
 
     # dynamic gpu params
     depth_end = depth_start + (tf.cast(depth_num, tf.float32) - 1) * depth_interval
@@ -159,16 +159,16 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_m
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=True)
     ref_feature = ref_tower.get_output()
     ref_feature2 = tf.square(ref_feature)
 
     view_features = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=True, training=training, mode=network_mode, reuse=True)
         view_features.append(view_tower.get_output())
     view_features = tf.stack(view_features, axis=0)
 
@@ -219,9 +219,9 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_m
 
     # filtered cost volume, size of (B, D, H, W, 1)
     if is_master_gpu:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode, reuse=False)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, training=training, mode=network_mode, reuse=False)
     else:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode,  reuse=True)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, trainable=True, training=training, mode=network_mode,  reuse=True)
     filtered_cost_volume = tf.squeeze(filtered_cost_volume_tower.get_output(), axis=-1)
 
     # depth map by softArgmin
@@ -229,7 +229,6 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_m
         # probability volume by soft max
         probability_volume = tf.nn.softmax(tf.scalar_mul(-1, filtered_cost_volume),
                                            axis=1, name='prob_volume')
-
         # depth image by soft argmin
         volume_shape = tf.shape(probability_volume)
         soft_2d = []
@@ -248,7 +247,7 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_m
     return estimated_depth_map, prob_map
 
 
-def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interval, network_mode,  is_master_gpu=True):
+def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True):
     """ infer disparity image from stereo images and cameras """
 
     # dynamic gpu params
@@ -260,13 +259,13 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, mode=network_mode, reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=True, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -330,7 +329,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
     return prob_volume
 
 def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, network_mode,
-                              is_master_gpu=True, reg_type='GRU', inverse_depth=False):
+                              is_master_gpu=True, reg_type='GRU', inverse_depth=False, training=True):
     """ infer disparity image from stereo images and cameras """
 
     if not inverse_depth:
@@ -342,13 +341,13 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode,  reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, trainable=True, training=training, mode=network_mode,  reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, mode=network_mode, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=True, training=training, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -463,7 +462,7 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
     forward_depth_map = depth_image
     return forward_depth_map, max_prob_image / forward_exp_sum
 
-def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True):
+def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True):
     """ refine depth image with the image """
 
     # normalization parameters
@@ -484,10 +483,10 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
     # refinement network
     if is_master_gpu:
         norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
-                                        is_training=True, mode=network_mode, reuse=False)
+                                        trainable=True, training=training, mode=network_mode, reuse=False)
     else:
         norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
-                                        is_training=True, mode=network_mode, reuse=True)
+                                        trainable=True, training=training, mode=network_mode, reuse=True)
     norm_depth_map = norm_depth_tower.get_output()
 
     # denormalize depth map
@@ -497,6 +496,6 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
     # way of doing things constrained the output of refine_conv3 to only take on very small values
     # which would lead to small gradients
     #refined_depth_map = tf.multiply(norm_depth_map, depth_scale_mat) + depth_start_mat
-    refined_depth_map = tf.add_n((norm_depth_map, init_depth_map),name='add_residual')
+    refined_depth_map = tf.add_n((norm_depth_map, init_depth_map), name='add_residual')
 
     return refined_depth_map

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -265,7 +265,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, trainable=trainable, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -286,9 +286,9 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])
     state2 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru2_filters])
     state3 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru3_filters])
-    conv_gru1 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru1_filters)
-    conv_gru2 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru2_filters)
-    conv_gru3 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru3_filters)
+    conv_gru1 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru1_filters, trainable=trainable)
+    conv_gru2 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru2_filters, trainable=trainable)
+    conv_gru3 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru3_filters, trainable=trainable)
 
     exp_div = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], 1])
     soft_depth_map = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], 1])
@@ -374,9 +374,9 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])
     state2 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru2_filters])
     state3 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru3_filters])
-    conv_gru1 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru1_filters)
-    conv_gru2 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru2_filters)
-    conv_gru3 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru3_filters)
+    conv_gru1 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru1_filters, trainable=trainable)
+    conv_gru2 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru2_filters, trainable=trainable)
+    conv_gru3 = ConvGRUCell(shape=gru_input_shape, kernel=[3, 3], filters=gru3_filters, trainable=trainable)
 
     # initialize variables
     exp_sum = tf.Variable(tf.zeros(

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -295,7 +295,12 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, i):
                 depth_map, depth_image, depth_interval)
             loss1, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
                 refined_depth_map, depth_image, depth_interval)
-            loss = (loss0 + loss1) / 2
+            if FLAGS.refinement_train_mode == 'refinement_only':
+                # If we are only training the refinement network we are only computing gradients wrt the refinement network params
+                # These gradients on l0 will be zero, so no need to include l0 in the loss
+                loss = loss1
+            else:
+                loss = (loss0 + loss1) / 2
         else:
             # regression loss
             loss, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -66,7 +66,7 @@ tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', False,
+tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
                             """One of 'all', 'refinement_only' or 'main_only'. If 'main_only' then only the main network is trained,
@@ -279,7 +279,7 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, i):
 
     # inference
     if FLAGS.regularization == '3DCNNs':
-        main_trainable = False if FLAGS.refinement_train_mode == 'refinement_only' and FLAGS.refinement=True else True
+        main_trainable = False if FLAGS.refinement_train_mode == 'refinement_only' and FLAGS.refinement==True else True
         # initial depth map
         depth_map, prob_map = inference(
             images, cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, is_master_gpu, trainable=main_trainable)

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -49,7 +49,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 32,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 256,
                             """Maximum image width when training.""")
@@ -62,13 +62,13 @@ tf.app.flags.DEFINE_float('interval_scale', 1.0,
 tf.app.flags.DEFINE_float('base_image_size', 8,
                           """Base image size""")
 # network architectures
-tf.app.flags.DEFINE_string('regularization', '3DCNNs',
+tf.app.flags.DEFINE_string('regularization', 'GRU',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('network_mode', 'ultralite',
+tf.app.flags.DEFINE_string('network_mode', 'lite',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -45,7 +45,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 192,
+tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('max_w', 640,
                             """Maximum image width when training.""")
@@ -60,9 +60,9 @@ tf.app.flags.DEFINE_float('base_image_size', 8,
 # network architectures
 tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
-tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
+tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', False,
+tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
 
 # training parameters
@@ -82,7 +82,7 @@ tf.app.flags.DEFINE_integer('stepvalue', None,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 10000,
                             """Step interval to save the model.""")
-tf.app.flags.DEFINE_float('gamma', 0.9,
+tf.app.flags.DEFINE_float('gamma', 0.5,
                           """Learning rate decay rate.""")
 tf.app.flags.DEFINE_float('val_batch_size', 5,
                           """Number of images to run validation on when validation.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -240,7 +240,8 @@ def initialize_trainer():
     logger.info("Tensorflow version: {}".format(tf.__version__))
     logger.info("Flags: {}".format(FLAGS))
     os.system('wandb login 08b2fe7c6c5d56f49b9c2dee8f24ca14c0679509') # Login to wandb
-    wandb.init(project='mvsnet')
+    wandb.init(project='mvsnet', tensorboard=True)
+    wandb.config.update(FLAGS)
 
     # Prepare validation summary 
     val_sum_file = os.path.join(
@@ -336,6 +337,7 @@ def validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, e
         print(Notify.INFO, '_validating_',
                 'epoch, %d, train step %d, val loss = %.4f, val (< 1px) = %.4f, val (< 3px) = %.4f (%.3f sec/step)' %
                 (epoch, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
+
         val_loss.append(out_loss)
         val_less_one.append(out_less_one)
         val_less_three.append(out_less_three)
@@ -345,6 +347,7 @@ def validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, e
 
     print(Notify.INFO, '\n VAL STEP COMPLETED. Average loss: {}, Average less one: {}, Average less three: {}\n'.format(
         l, l1, l3))
+    wandb.log({'loss':out_loss,'less_one':out_less_one,'less_three':out_less_three},step=total_step)
 
     with file_io.FileIO(val_sum_file, 'a+') as f:
         f.write('{},{},{},{}\n'.format(
@@ -414,6 +417,7 @@ def train():
                         print(Notify.INFO,
                               'epoch, %d, step %d, total_step %d, loss = %.4f, (< 1px) = %.4f, (< 3px) = %.4f (%.3f sec/step)' %
                               (epoch, step, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
+                        wandb.log({'loss':out_loss,'less_one':out_less_one,'less_three':out_less_three},step=total_step)
 
                     save_model(sess, saver, total_step, step)
                     step += FLAGS.batch_size * FLAGS.num_gpus

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when training.""")
-tf.app.flags.DEFINE_integer('width', 128,
+tf.app.flags.DEFINE_integer('width', 256,
                             """Maximum image width when training.""")
-tf.app.flags.DEFINE_integer('height', 96,
+tf.app.flags.DEFINE_integer('height', 192,
                             """Maximum image height when training.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume.""")
@@ -68,8 +68,8 @@ tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('network_mode', 'lite',
-                            """One of 'normal' or 'lite'. If 'lite' then networks have fewer params""")
+tf.app.flags.DEFINE_string('network_mode', 'ultralite',
+                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,
                             """Number of GPUs.""")
@@ -137,7 +137,6 @@ def average_gradients(tower_grads):
         # across towers. So .. we will just return the first tower's pointer to
         # the Variable.
         v = grad_and_vars[0][1]
-        logger.info('Variables:'.format(v))
         grad_and_var = (grad, v)
         average_grads.append(grad_and_var)
     return average_grads
@@ -347,7 +346,7 @@ def validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, e
 
     print(Notify.INFO, '\n VAL STEP COMPLETED. Average loss: {}, Average less one: {}, Average less three: {}\n'.format(
         l, l1, l3))
-    wandb.log({'loss':out_loss,'less_one':out_less_one,'less_three':out_less_three},step=total_step)
+    wandb.log({'val_loss':l,'val_less_one':l1,'val_less_three':l3}, step=total_step)
 
     with file_io.FileIO(val_sum_file, 'a+') as f:
         f.write('{},{},{},{}\n'.format(


### PR DESCRIPTION
This PR
* adds the 'refinement_train_mode' flag which allows you to alternatively train only the main network, or only the refinement network or both. 
* uses a different numerical scaling convention for the residual loss of the refinement network
