### PR TITLE
MVSNet improvements pt 2 -- encoder/decoder refinement network

### DIFF
--- a/mvsnet/cnn_wrapper/mvsnetworks.py
+++ b/mvsnet/cnn_wrapper/mvsnetworks.py
@@ -184,7 +184,8 @@ class RefineNet(Network):
 
 
 class RefineUNet(Network):
-    """Refinement network with 2D U-Net architecture and group normalization."""
+    """Refinement network with 2D U-Net architecture and group normalization.
+        Has the same input / output interface as the RefineNet above, but with a different body """
 
     def setup(self):
         base_filter = 8
@@ -194,54 +195,54 @@ class RefineUNet(Network):
          .concat(axis=3, name='concat_image'))
 
         (self.feed('concat_image')
-         .conv_gn(3, base_filter * 2, 2, center=True, scale=True, name='2dconv1_0')
-         .conv_gn(3, base_filter * 4, 2, center=True, scale=True, name='2dconv2_0')
-         .conv_gn(3, base_filter * 8, 2, center=True, scale=True, name='2dconv3_0')
-         .conv_gn(3, base_filter * 16, 2, center=True, scale=True, name='2dconv4_0'))
+         .conv_gn(3, base_filter * 2, 2, center=True, scale=True, name='2dconv1_0_refine')
+         .conv_gn(3, base_filter * 4, 2, center=True, scale=True, name='2dconv2_0_refine')
+         .conv_gn(3, base_filter * 8, 2, center=True, scale=True, name='2dconv3_0_refine')
+         .conv_gn(3, base_filter * 16, 2, center=True, scale=True, name='2dconv4_0_refine'))
 
         (self.feed('concat_image')
-         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv0_1')
-         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv0_2'))
+         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv0_1_refine')
+         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv0_2_refine'))
 
-        (self.feed('2dconv1_0')
-         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv1_1')
-         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv1_2'))
+        (self.feed('2dconv1_0_refine')
+         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv1_1_refine')
+         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv1_2_refine'))
 
-        (self.feed('2dconv2_0')
-         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv2_1')
-         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv2_2'))
+        (self.feed('2dconv2_0_refine')
+         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv2_1_refine')
+         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv2_2_refine'))
 
-        (self.feed('2dconv3_0')
-         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv3_1')
-         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv3_2'))
+        (self.feed('2dconv3_0_refine')
+         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv3_1_refine')
+         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv3_2_refine'))
 
-        (self.feed('2dconv4_0')
-         .conv_gn(3, base_filter * 16, 1, center=True, scale=True, name='2dconv4_1')
-         .conv_gn(3, base_filter * 16, 1, center=True, scale=True, name='2dconv4_2')
-         .deconv_gn(3, base_filter * 8, 2, center=True, scale=True, name='2dconv5_0'))
+        (self.feed('2dconv4_0_refine')
+         .conv_gn(3, base_filter * 16, 1, center=True, scale=True, name='2dconv4_1_refine')
+         .conv_gn(3, base_filter * 16, 1, center=True, scale=True, name='2dconv4_2_refine')
+         .deconv_gn(3, base_filter * 8, 2, center=True, scale=True, name='2dconv5_0_refine'))
 
-        (self.feed('2dconv5_0', '2dconv3_2')
-         .concat(axis=-1, name='2dconcat5_0')
-         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv5_1')
-         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv5_2')
-         .deconv_gn(3, base_filter * 4, 2, center=True, scale=True, name='2dconv6_0'))
+        (self.feed('2dconv5_0_refine', '2dconv3_2_refine')
+         .concat(axis=-1, name='2dconcat5_0_refine')
+         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv5_1_refine')
+         .conv_gn(3, base_filter * 8, 1, center=True, scale=True, name='2dconv5_2_refine')
+         .deconv_gn(3, base_filter * 4, 2, center=True, scale=True, name='2dconv6_0_refine'))
 
-        (self.feed('2dconv6_0', '2dconv2_2')
-         .concat(axis=-1, name='2dconcat6_0')
-         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv6_1')
-         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv6_2')
-         .deconv_gn(3, base_filter * 2, 2, center=True, scale=True, name='2dconv7_0'))
+        (self.feed('2dconv6_0_refine', '2dconv2_2_refine')
+         .concat(axis=-1, name='2dconcat6_0_refine')
+         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv6_1_refine')
+         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv6_2_refine')
+         .deconv_gn(3, base_filter * 2, 2, center=True, scale=True, name='2dconv7_0_refine'))
 
-        (self.feed('2dconv7_0', '2dconv1_2')
-         .concat(axis=-1, name='2dconcat7_0')
-         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv7_1')
-         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv7_2')
-         .deconv_gn(3, base_filter, 2, center=True, scale=True, name='2dconv8_0'))
+        (self.feed('2dconv7_0_refine', '2dconv1_2_refine')
+         .concat(axis=-1, name='2dconcat7_0_refine')
+         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv7_1_refine')
+         .conv_gn(3, base_filter * 2, 1, center=True, scale=True, name='2dconv7_2_refine')
+         .deconv_gn(3, base_filter, 2, center=True, scale=True, name='2dconv8_0_refine'))
 
-        (self.feed('2dconv8_0', '2dconv0_2')
-         .concat(axis=-1, name='2dconcat8_0')
-         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv8_1')
+        (self.feed('2dconv8_0_refine', '2dconv0_2_refine')
+         .concat(axis=-1, name='2dconcat8_0_refine')
+         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv8_1_refine')
          # end of UNet
-         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv8_2')
-         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv8_3')
-         .conv(3, 1, 1, relu=False, name='2dconv8_3'))
+         .conv_gn(3, base_filter, 1, center=True, scale=True, name='2dconv8_2_refine')
+         .conv_gn(3, base_filter * 4, 1, center=True, scale=True, name='2dconv8_3_refine')
+         .conv(3, 1, 1, relu=False, name='2dconv8_4_refine'))

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -62,7 +62,9 @@ tf.app.flags.DEFINE_bool('inverse_depth', True,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'ultralite',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-
+tf.app.flags.DEFINE_string('refinement_network', 'unet',
+                            """Specifies network to use for refinement. One of 'original' or 'unet'. 
+                            If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 FLAGS = tf.app.flags.FLAGS
 
 
@@ -123,7 +125,7 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
             ref_image = tf.squeeze(
                 tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(
-                init_depth_map, ref_image, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, True, training=False)
+                init_depth_map, ref_image, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,  True, training=False)
 
     # depth map inference using GRU
     elif FLAGS.regularization == 'GRU':

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -467,6 +467,7 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
 
     # normalization parameters
     depth_shape = tf.shape(init_depth_map)
+    image_shape = tf.shape(image)
     depth_end = depth_start + (tf.cast(depth_num, tf.float32) - 1) * depth_interval
     depth_start_mat = tf.tile(tf.reshape(
         depth_start, [depth_shape[0], 1, 1, 1]), [1, depth_shape[1], depth_shape[2], 1])
@@ -482,10 +483,10 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
 
     # refinement network
     if is_master_gpu:
-        norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
+        norm_depth_tower = RefineUNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
                                         trainable=trainable, training=training, mode=network_mode, reuse=False)
     else:
-        norm_depth_tower = RefineNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
+        norm_depth_tower = RefineUNet({'color_image': resized_image, 'depth_image': init_norm_depth_map},
                                         trainable=trainable, training=training, mode=network_mode, reuse=True)
     norm_depth_map = norm_depth_tower.get_output()
 

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -66,7 +66,7 @@ tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', False,
+tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
                             """One of 'all', 'refinement_only' or 'main_only'. If 'main_only' then only the main network is trained,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -74,6 +74,10 @@ tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
 tf.app.flags.DEFINE_string('network_mode', 'ultralite',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
+
+tf.app.flags.DEFINE_string('refinement_network', 'original',
+                            """Specifies network to use for refinement. One of 'original' or 'unet'. 
+                            If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,
                             """Number of GPUs.""")
@@ -289,7 +293,7 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, i):
             ref_image = tf.squeeze(
                 tf.slice(images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(depth_map, ref_image,
-                                                FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode,  is_master_gpu, trainable=refine_trainable)
+                                                FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,  is_master_gpu, trainable=refine_trainable)
                                     # regression loss
             loss0, less_one_temp, less_three_temp = mvsnet_regression_loss(
                 depth_map, depth_image, depth_interval)


### PR DESCRIPTION
This PR introduces the RefineUNet which is a different architecture for the refinement network. One can select between refinement networks using the refinement_network_type flag. I also did a bit of cleanup.

This PR also includes the changes from -- https://github.com/ubiquity6/MVSNet/pull/2 which should be reviewed and merged first, so I'm opening this up as a WIP until that happens


