### PR TITLE
[code quality] inference refactor + refine with confidence

### DIFF
--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -30,9 +30,9 @@ tf.app.flags.DEFINE_string('input_dir', None,
 tf.app.flags.DEFINE_string('output_dir', None,
                            """Path to data to dir to output results""")
 tf.app.flags.DEFINE_string('model_dir',
-                           'gs://mvs-training-mlengine/mvsnet_refine_geom_viewnum7_conf_refine_2/models/',
+                           'gs://mvs-training-mlengine/trained-models/06-04-2019/',
                            """Path to restore the model.""")
-tf.app.flags.DEFINE_integer('ckpt_step', 110000,
+tf.app.flags.DEFINE_integer('ckpt_step', 1350000,
                             """ckpt  step.""")
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 6,
@@ -57,7 +57,7 @@ tf.app.flags.DEFINE_bool('adaptive_scaling', True,
 # network architecture
 tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method, including '3DCNNs' and 'GRU'""")
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for MVSNet""")
 tf.app.flags.DEFINE_bool('inverse_depth', True,
                          """Whether to apply inverse depth for R-MVSNet""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -67,6 +67,8 @@ tf.app.flags.DEFINE_string('refinement_network', 'unet',
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 tf.app.flags.DEFINE_boolean('upsample_before_refinement', False,
                             """Whether to upsample depth map to input resolution before the refinement network.""")
+tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
+                            """Whether or not to concatenate the confidence map as an input channel to refinement network""")
 FLAGS = tf.app.flags.FLAGS
 
 
@@ -127,7 +129,8 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
             ref_image = tf.squeeze(
                 tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(
-                init_depth_map, ref_image, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,  True, training=False)
+                init_depth_map, ref_image, prob_map, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network, \
+                    True, training=False, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
 
     # depth map inference using GRU
     elif FLAGS.regularization == 'GRU':

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -36,11 +36,11 @@ tf.app.flags.DEFINE_integer('ckpt_step', 1350000,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 192,
+tf.app.flags.DEFINE_integer('max_d', 128,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 1024,
+tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 768,
+tf.app.flags.DEFINE_integer('height', 384,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -125,14 +125,14 @@ def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
     # depth map inference using 3DCNNs
     if FLAGS.regularization == '3DCNNs':
         init_depth_map, prob_map = inference_mem(
-            centered_images, scaled_cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, training=False)
+            centered_images, scaled_cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode)
 
         if FLAGS.refinement:
             ref_image = tf.squeeze(
                 tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(
                 init_depth_map, ref_image, prob_map, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,
-                True, training=False, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
+                True, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
 
     # depth map inference using GRU
     elif FLAGS.regularization == 'GRU':
@@ -206,7 +206,7 @@ def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
 
             # for png outputs
             write_depth_map(depth_png, out_init_depth_image,
-                            visualization=False)
+                            visualization=True)
             write_confidence_map(prob_png, out_prob_map)
 
             out_ref_image = cv2.cvtColor(out_ref_image, cv2.COLOR_RGB2BGR)

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -39,9 +39,9 @@ tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 256,
+tf.app.flags.DEFINE_integer('width', 1024,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 192,
+tf.app.flags.DEFINE_integer('height', 768,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -144,6 +144,9 @@ def get_depth_and_prob_map(centered_images, scaled_cams, depth_start, depth_inte
     return init_depth_map, prob_map
 
 
+def get_sample
+
+
 def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
     """ Performs inference using trained MVSNet model on data located in input_dir """
     if width and height:
@@ -176,24 +179,6 @@ def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
     init_depth_map, prob_map = get_depth_and_prob_map(
         centered_images, scaled_cams, depth_start, depth_interval)
 
-    """
-    # depth map inference using 3DCNNs
-    if FLAGS.regularization == '3DCNNs':
-        init_depth_map, prob_map = inference_mem(
-            centered_images, scaled_cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode)
-
-        if FLAGS.refinement:
-            ref_image = tf.squeeze(
-                tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
-            init_depth_map = depth_refine(
-                init_depth_map, ref_image, prob_map, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,
-                True, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
-
-    # depth map inference using GRU
-    elif FLAGS.regularization == 'GRU':
-        init_depth_map, prob_map = inference_winner_take_all(centered_images, scaled_cams,
-                                                             depth_num, depth_start, depth_end, network_mode=FLAGS.network_mode, reg_type='GRU', inverse_depth=FLAGS.inverse_depth, training=False)
-    """
     # init option
     var_init_op = tf.local_variables_initializer()
     init_op, config = mu.init_session()

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -74,7 +74,7 @@ FLAGS = tf.app.flags.FLAGS
 
 
 def setup_data_iterator(input_dir):
-    # testing set
+    "Configures the data generator that is used to feed batches of data for inference"
     data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height,
                                 FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='test')
     mvs_generator = iter(data_gen)
@@ -93,7 +93,7 @@ def setup_data_iterator(input_dir):
 
 
 def setup_output_dir(input_dir, output_dir):
-    # create output folder
+    "Creates output dir for saving mvsnet output"
     if output_dir is None:
         output_dir = os.path.join(input_dir, 'depths_mvsnet')
     mu.mkdir_p(output_dir)

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -36,7 +36,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', 1350000,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 256,
+tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when testing.""")
 tf.app.flags.DEFINE_integer('width', 1024,
                             """Maximum image width when testing.""")
@@ -61,9 +61,9 @@ tf.app.flags.DEFINE_boolean('refinement', False,
 tf.app.flags.DEFINE_bool('inverse_depth', True,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'normal',
-                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
+                           """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
 tf.app.flags.DEFINE_string('refinement_network', 'unet',
-                            """Specifies network to use for refinement. One of 'original' or 'unet'. 
+                           """Specifies network to use for refinement. One of 'original' or 'unet'. 
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 tf.app.flags.DEFINE_boolean('upsample_before_refinement', False,
                             """Whether to upsample depth map to input resolution before the refinement network.""")
@@ -72,11 +72,12 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
 FLAGS = tf.app.flags.FLAGS
 
 
-def compute_depth_maps(input_dir, output_dir = None, width = None, height = None):
+def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
     """ Performs inference using trained MVSNet model on data located in input_dir """
     if width and height:
         FLAGS.width, FLAGS.height = width, height
-    logger.info('Computing depth maps with MVSNet. Using input width x height = {} x {}'.format(FLAGS.width,FLAGS.height))
+    logger.info('Computing depth maps with MVSNet. Using input width x height = {} x {}'.format(
+        FLAGS.width, FLAGS.height))
 
     # create output folder
     if output_dir is None:
@@ -89,7 +90,8 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
     mvs_generator = iter(data_gen)
     sample_size = len(data_gen.train_clusters)
 
-    generator_data_type = (tf.float32, tf.float32, tf.float32, tf.float32, tf.int32)
+    generator_data_type = (tf.float32, tf.float32,
+                           tf.float32, tf.float32, tf.int32)
     mvs_set = tf.data.Dataset.from_generator(
         lambda: mvs_generator, generator_data_type)
     mvs_set = mvs_set.batch(FLAGS.batch_size)
@@ -129,8 +131,8 @@ def compute_depth_maps(input_dir, output_dir = None, width = None, height = None
             ref_image = tf.squeeze(
                 tf.slice(centered_images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
             refined_depth_map = depth_refine(
-                init_depth_map, ref_image, prob_map, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network, \
-                    True, training=False, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
+                init_depth_map, ref_image, prob_map, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, FLAGS.refinement_network,
+                True, training=False, upsample_depth=FLAGS.upsample_before_refinement, refine_with_confidence=FLAGS.refine_with_confidence)
 
     # depth map inference using GRU
     elif FLAGS.regularization == 'GRU':

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -36,7 +36,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', 1350000,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
 tf.app.flags.DEFINE_integer('width', 1024,
                             """Maximum image width when testing.""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -39,9 +39,9 @@ tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 640,
+tf.app.flags.DEFINE_integer('width', 256,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 480,
+tf.app.flags.DEFINE_integer('height', 192,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")

--- a/mvsnet/loss.py
+++ b/mvsnet/loss.py
@@ -12,7 +12,7 @@ import numpy as np
 FLAGS = tf.app.flags.FLAGS
 
 
-def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=2):
+def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=1):
     """ non zero mean absolute loss for one batch """
     with tf.name_scope('MAE'):
         denom_exponent = tf.constant(denom_exponent, dtype=tf.float32)
@@ -21,15 +21,13 @@ def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=2):
         mask_true = tf.cast(tf.not_equal(y_true, 0.0), dtype='float32')
         denom = tf.abs(tf.reduce_sum(mask_true, axis=[1, 2, 3])) + 1e-6
         # scaling loss by alpha ensures that loss is of order 1
-        alpha = tf.math.pow(tf.reduce_mean(denom), denom_exponent - 1) * .02
-        #alpha = tf.constant(20000, dtype=tf.float32)
+        alpha = tf.math.pow(tf.reduce_mean(denom), denom_exponent - 1)
         denom = tf.math.pow(denom, denom_exponent)
         masked_abs_error = tf.abs(
             mask_true * (y_true - y_pred))            # 4D
         masked_mae = tf.reduce_sum(masked_abs_error, axis=[1, 2, 3])
-        # masked_mae = tf.reduce_sum(
-        #    (masked_mae / interval) / denom) * alpha       # 1
-        masked_mae = tf.reduce_sum(masked_mae / denom) * alpha       # 1
+        masked_mae = tf.reduce_sum(
+            (masked_mae / interval) / denom) * alpha       # 1
     return masked_mae
 
 

--- a/mvsnet/loss.py
+++ b/mvsnet/loss.py
@@ -11,7 +11,8 @@ import numpy as np
 
 FLAGS = tf.app.flags.FLAGS
 
-def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=1):
+
+def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=2):
     """ non zero mean absolute loss for one batch """
     with tf.name_scope('MAE'):
         denom_exponent = tf.constant(denom_exponent, dtype=tf.float32)
@@ -19,11 +20,18 @@ def non_zero_mean_absolute_diff(y_true, y_pred, interval, denom_exponent=1):
         interval = tf.reshape(interval, [shape[0]])
         mask_true = tf.cast(tf.not_equal(y_true, 0.0), dtype='float32')
         denom = tf.abs(tf.reduce_sum(mask_true, axis=[1, 2, 3])) + 1e-6
+        # scaling loss by alpha ensures that loss is of order 1
+        alpha = tf.math.pow(tf.reduce_mean(denom), denom_exponent - 1) * .02
+        #alpha = tf.constant(20000, dtype=tf.float32)
         denom = tf.math.pow(denom, denom_exponent)
-        masked_abs_error = tf.abs(mask_true * (y_true - y_pred))            # 4D
-        masked_mae = tf.reduce_sum(masked_abs_error, axis=[1, 2, 3])        # 1D
-        masked_mae = tf.reduce_sum((masked_mae / interval) / denom)         # 1
+        masked_abs_error = tf.abs(
+            mask_true * (y_true - y_pred))            # 4D
+        masked_mae = tf.reduce_sum(masked_abs_error, axis=[1, 2, 3])
+        # masked_mae = tf.reduce_sum(
+        #    (masked_mae / interval) / denom) * alpha       # 1
+        masked_mae = tf.reduce_sum(masked_mae / denom) * alpha       # 1
     return masked_mae
+
 
 def less_one_percentage(y_true, y_pred, interval):
     """ less one accuracy for one batch """
@@ -31,10 +39,13 @@ def less_one_percentage(y_true, y_pred, interval):
         shape = tf.shape(y_pred)
         mask_true = tf.cast(tf.not_equal(y_true, 0.0), dtype='float32')
         denom = tf.abs(tf.reduce_sum(mask_true)) + 1e-6
-        interval_image = tf.tile(tf.reshape(interval, [shape[0], 1, 1, 1]), [1, shape[1], shape[2], 1])
+        interval_image = tf.tile(tf.reshape(interval, [shape[0], 1, 1, 1]), [
+                                 1, shape[1], shape[2], 1])
         abs_diff_image = tf.abs(y_true - y_pred) / interval_image
-        less_one_image = mask_true * tf.cast(tf.less_equal(abs_diff_image, 1.0), dtype='float32')
+        less_one_image = mask_true * \
+            tf.cast(tf.less_equal(abs_diff_image, 1.0), dtype='float32')
     return tf.reduce_sum(less_one_image) / denom
+
 
 def less_three_percentage(y_true, y_pred, interval):
     """ less three accuracy for one batch """
@@ -42,19 +53,25 @@ def less_three_percentage(y_true, y_pred, interval):
         shape = tf.shape(y_pred)
         mask_true = tf.cast(tf.not_equal(y_true, 0.0), dtype='float32')
         denom = tf.abs(tf.reduce_sum(mask_true)) + 1e-6
-        interval_image = tf.tile(tf.reshape(interval, [shape[0], 1, 1, 1]), [1, shape[1], shape[2], 1])
+        interval_image = tf.tile(tf.reshape(interval, [shape[0], 1, 1, 1]), [
+                                 1, shape[1], shape[2], 1])
         abs_diff_image = tf.abs(y_true - y_pred) / interval_image
-        less_three_image = mask_true * tf.cast(tf.less_equal(abs_diff_image, 3.0), dtype='float32')
+        less_three_image = mask_true * \
+            tf.cast(tf.less_equal(abs_diff_image, 3.0), dtype='float32')
     return tf.reduce_sum(less_three_image) / denom
+
 
 def mvsnet_regression_loss(estimated_depth_image, depth_image, depth_interval):
     """ compute loss and accuracy """
     # non zero mean absulote loss
-    masked_mae = non_zero_mean_absolute_diff(depth_image, estimated_depth_image, depth_interval)
+    masked_mae = non_zero_mean_absolute_diff(
+        depth_image, estimated_depth_image, depth_interval)
     # less one accuracy
-    less_one_accuracy = less_one_percentage(depth_image, estimated_depth_image, depth_interval)
+    less_one_accuracy = less_one_percentage(
+        depth_image, estimated_depth_image, depth_interval)
     # less three accuracy
-    less_three_accuracy = less_three_percentage(depth_image, estimated_depth_image, depth_interval)
+    less_three_accuracy = less_three_percentage(
+        depth_image, estimated_depth_image, depth_interval)
 
     return masked_mae, less_one_accuracy, less_three_accuracy
 
@@ -67,31 +84,40 @@ def mvsnet_classification_loss(prob_volume, gt_depth_image, depth_num, depth_sta
     valid_pixel_num = tf.reduce_sum(mask_true, axis=[1, 2, 3]) + 1e-7
     # gt depth map -> gt index map
     shape = tf.shape(gt_depth_image)
-    depth_end = depth_start + (tf.cast(depth_num, tf.float32) - 1) * depth_interval
-    start_mat = tf.tile(tf.reshape(depth_start, [shape[0], 1, 1, 1]), [1, shape[1], shape[2], 1])
+    depth_end = depth_start + \
+        (tf.cast(depth_num, tf.float32) - 1) * depth_interval
+    start_mat = tf.tile(tf.reshape(depth_start, [shape[0], 1, 1, 1]), [
+                        1, shape[1], shape[2], 1])
 
-    interval_mat = tf.tile(tf.reshape(depth_interval, [shape[0], 1, 1, 1]), [1, shape[1], shape[2], 1])
+    interval_mat = tf.tile(tf.reshape(depth_interval, [shape[0], 1, 1, 1]), [
+                           1, shape[1], shape[2], 1])
     gt_index_image = tf.div(gt_depth_image - start_mat, interval_mat)
     gt_index_image = tf.multiply(mask_true, gt_index_image)
     gt_index_image = tf.cast(tf.round(gt_index_image), dtype='int32')
     # gt index map -> gt one hot volume (B x H x W x 1)
     gt_index_volume = tf.one_hot(gt_index_image, depth_num, axis=1)
     # cross entropy image (B x H x W x 1)
-    cross_entropy_image = -tf.reduce_sum(gt_index_volume * tf.log(prob_volume), axis=1)
+    cross_entropy_image = - \
+        tf.reduce_sum(gt_index_volume * tf.log(prob_volume), axis=1)
     # masked cross entropy loss
     masked_cross_entropy_image = tf.multiply(mask_true, cross_entropy_image)
-    masked_cross_entropy = tf.reduce_sum(masked_cross_entropy_image, axis=[1, 2, 3])
-    masked_cross_entropy = tf.reduce_sum(masked_cross_entropy / valid_pixel_num)
+    masked_cross_entropy = tf.reduce_sum(
+        masked_cross_entropy_image, axis=[1, 2, 3])
+    masked_cross_entropy = tf.reduce_sum(
+        masked_cross_entropy / valid_pixel_num)
 
     # winner-take-all depth map
     wta_index_map = tf.cast(tf.argmax(prob_volume, axis=1), dtype='float32')
-    wta_depth_map = wta_index_map * interval_mat + start_mat    
+    wta_depth_map = wta_index_map * interval_mat + start_mat
 
     # non zero mean absulote loss
-    masked_mae = non_zero_mean_absolute_diff(gt_depth_image, wta_depth_map, tf.abs(depth_interval))
+    masked_mae = non_zero_mean_absolute_diff(
+        gt_depth_image, wta_depth_map, tf.abs(depth_interval))
     # less one accuracy
-    less_one_accuracy = less_one_percentage(gt_depth_image, wta_depth_map, tf.abs(depth_interval))
+    less_one_accuracy = less_one_percentage(
+        gt_depth_image, wta_depth_map, tf.abs(depth_interval))
     # less three accuracy
-    less_three_accuracy = less_three_percentage(gt_depth_image, wta_depth_map, tf.abs(depth_interval))
+    less_three_accuracy = less_three_percentage(
+        gt_depth_image, wta_depth_map, tf.abs(depth_interval))
 
     return masked_cross_entropy, masked_mae, less_one_accuracy, less_three_accuracy, wta_depth_map

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -475,13 +475,14 @@ def depth_refine(init_depth_map, image, prob_map, depth_num, depth_start, depth_
         init_norm_depth_map = tf.image.resize_bilinear(init_norm_depth_map, [image_shape[1], image_shape[2]])
         init_depth_map = tf.image.resize_bilinear(init_depth_map, [image_shape[1], image_shape[2]])
         if refine_with_confidence:
+            # TODO: resize the probability map with nearest neighbor interpolation instead of bilinear
             prob_map = tf.image.resize_bilinear(prob_map, [image_shape[1], image_shape[2]])
     else:
         # Downsample original image to size of depth map
         image = tf.image.resize_bilinear(image, [depth_shape[1], depth_shape[2]])
     
     if refine_with_confidence:
-        init_norm_depth_map = tf.concat([init_norm_depth_map, prob_map], axis=0)
+        init_norm_depth_map = tf.concat([init_norm_depth_map, prob_map], axis=3)
 
 
     # refinement network

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -144,7 +144,6 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_mode, is_master_gpu=True, training=True, trainable=True):
     """ inference of depth image from multi-view images and cameras """
 
-
     # dynamic gpu params
     depth_end = depth_start + (tf.cast(depth_num, tf.float32) - 1) * depth_interval
     feature_c = 32
@@ -454,7 +453,8 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
     forward_depth_map = depth_image
     return forward_depth_map, max_prob_image / forward_exp_sum
 
-def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, network_mode, network_type, is_master_gpu=True, training=True, trainable=True, upsample_depth=False):
+def depth_refine(init_depth_map, image, prob_map, depth_num, depth_start, depth_interval, network_mode, network_type, \
+    is_master_gpu=True, training=True, trainable=True, upsample_depth=False, refine_with_confidence=False):
     """ refine depth image with the image """
 
     # normalization parameters
@@ -474,9 +474,15 @@ def depth_refine(init_depth_map, image, depth_num, depth_start, depth_interval, 
         # Upsample depth map to resolution of input image
         init_norm_depth_map = tf.image.resize_bilinear(init_norm_depth_map, [image_shape[1], image_shape[2]])
         init_depth_map = tf.image.resize_bilinear(init_depth_map, [image_shape[1], image_shape[2]])
+        if refine_with_confidence:
+            prob_map = tf.image.resize_bilinear(prob_map, [image_shape[1], image_shape[2]])
     else:
         # Downsample original image to size of depth map
         image = tf.image.resize_bilinear(image, [depth_shape[1], depth_shape[2]])
+    
+    if refine_with_confidence:
+        init_norm_depth_map = tf.concat([init_norm_depth_map, prob_map], axis=0)
+
 
     # refinement network
     reuse = not is_master_gpu

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -237,12 +237,10 @@ class ClusterGenerator:
                     full_cams = np.stack(cropped_cams, axis=0)
                     # Scaled for input size
                     input_images = ut.copy_and_center_images(cropped_images)
-
                     # Scaled to the output size of network
-                    # Scaled cams are used for the differential homography step
+                    # Scaled cams are used for the differential homography warping
                     output_images, output_cams = ut.scale_mvs_input(
                         cropped_images, cropped_cams, scale=self.output_scale)
-
                     output_images = np.stack(output_images, axis=0)
                     output_cams = np.stack(output_cams, axis=0)
 

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -40,7 +40,7 @@ class ClusterGenerator:
         self.output_scale = output_scale
         self.flip_cams = flip_cams
         # The sessions_fraction [0,1] is the fraction of all available sessions in sessions_dir
-        self.sessions_frac = 0.2
+        self.sessions_frac = 1.0
         self.parse_sessions()
         self.set_iter_clusters()
 
@@ -64,6 +64,7 @@ class ClusterGenerator:
         else:
             sessions = [f for f in tf.gfile.ListDirectory(
                 self.sessions_dir) if not f.startswith('.') if not f.endswith('.txt')]
+            sessions = sorted(sessions)
             total_sessions = len(sessions)
             self.logger.info(
                 'There are {} total sessions'.format(total_sessions))

--- a/mvsnet/preprocess.py
+++ b/mvsnet/preprocess.py
@@ -171,25 +171,23 @@ def pose_string(cam):
     return pose_string
 
 
-def write_inverse_depth_map(image, file_path, exp=0.25):
-    """ Writes an inverted depth map for visualization purposes. exp is a value in [0,1]. Use a higher (lower)
-    value for faster (slower) decay with distance """
-    file_path_inverse = file_path.replace('.png', '_inverse.png')
+def write_inverse_depth_map(image, file_path, exp=2):
+    """ Writes an inverted depth map for visualization purposes
+    args:
+        image: Depth image to write
+        file_path: Path where that image is
+        exp: A positive number. Higher numbers lead to faster decay of brightness with depth"""
+    file_path_inverse = file_path.replace('.png', '_inverse_3.png')
+    max_int = 65535
     image = image.astype(np.float)
-    image = image - image.min()
-    image *= (65535 / image.max())
-    inv_depth = 65535 / np.power((1+image),exp) - np.power(image, 1-exp)
-    inv_depth = np.clip(inv_depth, 0, 65535).astype(np.uint16)
+    # First normalize image so it has min 0 and max = max_int
+    image -= image.min()
+    image *= (max_int / image.max())
+    # Invert the depth map and clip values
+    inv_depth = np.power((max_int - image)/max_int,exp)*max_int
+    inv_depth = np.clip(inv_depth, 0, max_int).astype(np.uint16)
     imageio.imsave(file_path_inverse, inv_depth)
 
-
-def write_inverse_depth_map_2(image, file_path, exp=0.25):
-    """ Writes an inverted depth map for visualization purposes. exp is a value in [0,1]. Use a higher (lower)
-    value for faster (slower) decay with distance """
-    file_path_inverse = file_path.replace('.png', '_inverse_2.png')
-    inv_depth = 65535 - image
-    inv_depth = np.clip(inv_depth, 0, 65535).astype(np.uint16)
-    imageio.imsave(file_path_inverse, inv_depth)
 
 def write_depth_map(file_path, image, visualization = True):
     # convert to int and clip to range of [0, 2^16 -1]
@@ -197,9 +195,6 @@ def write_depth_map(file_path, image, visualization = True):
     imageio.imsave(file_path, image)
     if visualization:
         write_inverse_depth_map(image, file_path)
-
-
-
 
 def write_confidence_map(file_path, image):
     # we convert probabilities in range [0,1] to ints in range [0, 2^16-1]

--- a/mvsnet/preprocess.py
+++ b/mvsnet/preprocess.py
@@ -171,18 +171,32 @@ def pose_string(cam):
     return pose_string
 
 
-def write_visualization_depth_map(image, file_path):
-    file_path_scaled = file_path.replace('.png', '_scaled.png')
-    # rescales the image so max distance is 6.5 meters, making contrast more visible
-    image_scaled = np.clip(image*50, 0, 65535).astype(np.uint16)
-    imageio.imsave(file_path_scaled, image_scaled)
+def write_inverse_depth_map(image, file_path, exp=0.25):
+    """ Writes an inverted depth map for visualization purposes. exp is a value in [0,1]. Use a higher (lower)
+    value for faster (slower) decay with distance """
+    file_path_inverse = file_path.replace('.png', '_inverse.png')
+    image = image.astype(np.float)
+    image = image - image.min()
+    image *= (65535 / image.max())
+    inv_depth = 65535 / np.power((1+image),exp) - np.power(image, 1-exp)
+    inv_depth = np.clip(inv_depth, 0, 65535).astype(np.uint16)
+    imageio.imsave(file_path_inverse, inv_depth)
 
-def write_depth_map(file_path, image, visualization = False):
+
+def write_inverse_depth_map_2(image, file_path, exp=0.25):
+    """ Writes an inverted depth map for visualization purposes. exp is a value in [0,1]. Use a higher (lower)
+    value for faster (slower) decay with distance """
+    file_path_inverse = file_path.replace('.png', '_inverse_2.png')
+    inv_depth = 65535 - image
+    inv_depth = np.clip(inv_depth, 0, 65535).astype(np.uint16)
+    imageio.imsave(file_path_inverse, inv_depth)
+
+def write_depth_map(file_path, image, visualization = True):
     # convert to int and clip to range of [0, 2^16 -1]
     image = np.clip(image, 0, 65535).astype(np.uint16)
     imageio.imsave(file_path, image)
     if visualization:
-        write_visualization_depth_map(image, file_path)
+        write_inverse_depth_map(image, file_path)
 
 
 

--- a/mvsnet/preprocess.py
+++ b/mvsnet/preprocess.py
@@ -177,7 +177,7 @@ def write_inverse_depth_map(image, file_path, exp=2):
         image: Depth image to write
         file_path: Path where that image is
         exp: A positive number. Higher numbers lead to faster decay of brightness with depth"""
-    file_path_inverse = file_path.replace('.png', '_inverse_3.png')
+    file_path_inverse = file_path.replace('.png', '_inverse.png')
     max_int = 65535
     image = image.astype(np.float)
     # First normalize image so it has min 0 and max = max_int

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -74,7 +74,7 @@ tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
-tf.app.flags.DEFINE_string('network_mode', 'normal',
+tf.app.flags.DEFINE_string('network_mode', 'lite',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
 
 tf.app.flags.DEFINE_string('refinement_network', 'unet',

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 3,
+tf.app.flags.DEFINE_integer('view_num', 7,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 32,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
@@ -72,7 +72,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -81,9 +81,9 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 tf.app.flags.DEFINE_string('refinement_network', 'original',
                             """Specifies network to use for refinement. One of 'original' or 'unet'. 
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
-tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
+tf.app.flags.DEFINE_boolean('upsample_before_refinement', False,
                             """Whether to upsample depth map to input resolution before the refinement network""")
-tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
+tf.app.flags.DEFINE_boolean('refine_with_confidence', False,
                             """Whether or not to concatenate the confidence map as an input channel to refinement network""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -68,7 +68,7 @@ tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
@@ -232,7 +232,7 @@ def setup_optimizer():
 
     if FLAGS.stepvalue is None:
         # With this stepvalue, the lr will decay by a factor of decay_per_10_epoch every 10 epochs
-        decay_per_10_epoch = 0.025
+        decay_per_10_epoch = 0.1
         FLAGS.stepvalue = int(
             10 * np.log(FLAGS.gamma) * training_sample_size / np.log(decay_per_10_epoch))
     global_step = tf.Variable(0, trainable=False, name='global_step')

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -71,8 +71,8 @@ tf.app.flags.DEFINE_string('optimizer', 'momentum',
 tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
-                            """One of 'all', 'refinement_only' or 'main_only'. If 'main_only' then only the main network is trained,
-                            if 'refinement_only', only the refinement network is trained, and if 'all' then the whole network is trained.
+                            """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
+                            if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
@@ -299,7 +299,7 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, full_depth,
 
     # inference
     if FLAGS.regularization == '3DCNNs':
-        main_trainable = False if FLAGS.refinement_train_mode == 'refinement_only' and FLAGS.refinement==True else True
+        main_trainable = False if FLAGS.refinement_train_mode == 'refine_only' and FLAGS.refinement==True else True
         # initial depth map
         depth_map, prob_map = inference(
             images, cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, is_master_gpu, trainable=main_trainable)
@@ -320,7 +320,7 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, full_depth,
             else:
                 loss1, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
                     refined_depth_map, depth_image, depth_interval)
-            if FLAGS.refinement_train_mode == 'refinement_only':
+            if FLAGS.refinement_train_mode == 'refine_only':
                 # If we are only training the refinement network we are only computing gradients wrt the refinement network params
                 # These gradients on l0 will be zero, so no need to include l0 in the loss
                 loss = loss1

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,11 +51,11 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
-tf.app.flags.DEFINE_integer('width', 256,
+tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
-tf.app.flags.DEFINE_integer('height', 192,
+tf.app.flags.DEFINE_integer('height', 480,
                             """Maximum image height when training.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume.""")
@@ -68,7 +68,7 @@ tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', False,
+tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
@@ -97,7 +97,7 @@ tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
 tf.app.flags.DEFINE_integer('stepvalue', None,
                             """Step interval to decay learning rate.""")
-tf.app.flags.DEFINE_integer('snapshot', 1000,
+tf.app.flags.DEFINE_integer('snapshot', 2000,
                             """Step interval to save the model.""")
 tf.app.flags.DEFINE_float('gamma', 0.5,
                           """Learning rate decay rate.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -38,7 +38,7 @@ tf.app.flags.DEFINE_string('log_dir', None,
 tf.app.flags.DEFINE_string('model_dir', None,
                            """Path to save the model.""")
 tf.app.flags.DEFINE_string('model_load_dir', None,
-                           """Path to load the saved model. Required if ckpt_step is not none""")
+                           """Path to load the saved model. If not specified, model will be loaded from model_dir""")
 tf.app.flags.DEFINE_string('job-dir', None,
                            """Path to save job artifacts""")
 tf.app.flags.DEFINE_boolean('train_dtu', True,
@@ -70,7 +70,7 @@ tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -112,11 +112,13 @@ def load_model(sess):
     """ Loads pretrained model if supplied """
     total_step = 0
     if FLAGS.ckpt_step:
-        pretrained_model_path = os.path.join(
-            FLAGS.model_load_dir, FLAGS.regularization, 'model.ckpt')
+        if FLAGS.model_load_dir:
+            pretrained_model_path = os.path.join(
+                FLAGS.model_load_dir, FLAGS.regularization, 'model.ckpt')
+        else:
+            pretrained_model_path = os.path.join(
+                FLAGS.model_dir, FLAGS.regularization, 'model.ckpt')
         restorer = tf.train.Saver(tf.global_variables())
-        restorer.restore(
-            sess, '-'.join([pretrained_model_path, str(60)]))
         restorer.restore(
             sess, '-'.join([pretrained_model_path, str(FLAGS.ckpt_step)]))
         print(Notify.INFO, 'Pre-trained model restored from %s' %

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 7,
+tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 192,
+tf.app.flags.DEFINE_integer('max_d', 384,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
@@ -70,7 +70,7 @@ tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
 tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -314,6 +314,7 @@ def get_loss(images, cams, depth_image, depth_start, depth_interval, full_depth,
             loss0, less_one_temp, less_three_temp = mvsnet_regression_loss(
                 depth_map, depth_image, depth_interval)
             # If we upsampled the depth image to full resolution we need to compute loss with full_depth
+            
             if FLAGS.upsample_before_refinement:
                 loss1, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
                     refined_depth_map, full_depth, depth_interval)

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,7 +51,7 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 6,
+tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
@@ -69,16 +69,15 @@ tf.app.flags.DEFINE_float('base_image_size', 8,
 tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method.""")
 tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
-                           """Optimizer to use. One of 'momentum' or 'rmsprop' """)
-tf.app.flags.DEFINE_boolean('refinement', False,
+                           """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
+tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                             """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-
 tf.app.flags.DEFINE_string('refinement_network', 'unet',
                             """Specifies network to use for refinement. One of 'original' or 'unet'. 
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
@@ -244,6 +243,9 @@ def setup_optimizer():
     elif FLAGS.optimizer == 'momentum':
         opt = tf.train.MomentumOptimizer(
             learning_rate=lr_op, momentum=0.9, use_nesterov=False)
+        return opt, global_step
+    elif FLAGS.optimizer == 'adam':
+        opt = tf.train.AdamOptimizer(learning_rate=lr_op)
         return opt, global_step
     else:
         logger.error("Optimizer {} is not implemented. Please use 'rmsprop' or 'momentum".format(

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -53,15 +53,9 @@ tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
-<<<<<<< HEAD
 tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
 tf.app.flags.DEFINE_integer('height', 480,
-=======
-tf.app.flags.DEFINE_integer('width', 128,
-                            """Maximum image width when training.""")
-tf.app.flags.DEFINE_integer('height', 96,
->>>>>>> chris/freeze
                             """Maximum image height when training.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume.""")
@@ -76,11 +70,7 @@ tf.app.flags.DEFINE_string('optimizer', 'momentum',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-<<<<<<< HEAD
 tf.app.flags.DEFINE_string('refinement_train_mode', 'all',
-=======
-tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
->>>>>>> chris/freeze
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy>=0.18
 matplotlib>=1.5
 Pillow>=3.1.2
 nvidia-ml-py
+wandb

--- a/scripts/sketchfab.py
+++ b/scripts/sketchfab.py
@@ -35,8 +35,6 @@ def upload(model_file, api_token='5f2cad0a1eff43699ebe0765b8d9a8ba', name='', de
 
    # password = 'my-password'  # requires a pro account
    # private = 1  # requires a pro account
-    tags = ['bob', 'character', 'video-games']  # Array of tags
-    categories = ['people']  # Array of categories slugs
     license = 'CC Attribution'  # License label
     isPublished = True,  # Model will be on draft instead of published
     isInspectable = True,  # Allow 2D view in model inspector
@@ -44,8 +42,6 @@ def upload(model_file, api_token='5f2cad0a1eff43699ebe0765b8d9a8ba', name='', de
     data = {
         'name': name,
         'description': description,
-        'tags': tags,
-        'categories': categories,
         'license': license,
         # 'private': private,
         # 'password': password,


### PR DESCRIPTION
This PR refactors the main inference method so that:
- It is composed of more modular functions with better documentation
- Inference is compatible with refinement (previously disabled)

It also includes a couple changes from the last round of experimental improvements such as

- The ability to concatenate confidence maps with refinement network
- The ability to adjust the exponent if GT depth in loss normalization