### PR TITLE
GT Benchmarking for mvsnet depth

### DIFF
--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -80,7 +80,7 @@ tf.app.flags.DEFINE_bool('visualize', True,
                          This is useful when developing and debugging, but should probably be turned off in production""")
 tf.app.flags.DEFINE_bool('wandb', False,
                          """Whether or not to log inference results to wandb""")
-tf.app.flags.DEFINE_bool('benchmark', True,
+tf.app.flags.DEFINE_bool('benchmark', False,
                          """If benchmark is True, the network results will be benchmarked against GT.
                          This should only be used if the input_dir contains GT depth maps""")
 tf.app.flags.DEFINE_bool('write_output', False,
@@ -88,7 +88,7 @@ tf.app.flags.DEFINE_bool('write_output', False,
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")
-tf.app.flags.DEFINE_integer('max_clusters_per_session', 4,
+tf.app.flags.DEFINE_integer('max_clusters_per_session', None,
                             """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -83,10 +83,12 @@ tf.app.flags.DEFINE_bool('wandb', False,
 tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.
                          This should only be used if the input_dir contains GT depth maps""")
+tf.app.flags.DEFINE_bool('write_output', False,
+                         """When benchmarking you can set this to False if you don't need the output""")
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")
-tf.app.flags.DEFINE_integer('max_clusters_per_session', 20,
+tf.app.flags.DEFINE_integer('max_clusters_per_session', 2,
                             """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 
@@ -357,9 +359,9 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
 
             write_dir = os.path.join(str(out_session_dir[0]), 'depths_mvsnet') 
             mu.mkdir_p(write_dir)
-            print('writing output to {}'.format(write_dir))
-            write_output(write_dir, out_depth_map, out_prob_map, out_images,
-                         out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
+            if FLAGS.write_output:
+                write_output(write_dir, out_depth_map, out_prob_map, out_images,
+                            out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
             losses.append(out_loss)
             less_ones.append(out_less_one)
             less_threes.append(out_less_three)

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,13 +38,13 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 8,
+tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 256,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 1024,
+tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 768,
+tf.app.flags.DEFINE_integer('height', 384,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -66,10 +66,10 @@ tf.app.flags.DEFINE_bool('inverse_depth', False,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-tf.app.flags.DEFINE_string('refinement_network', 'unet',
+tf.app.flags.DEFINE_string('refinement_network', 'original',
                            """Specifies network to use for refinement. One of 'original' or 'unet'.
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
-tf.app.flags.DEFINE_boolean('upsample_before_refinement', False,
+tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
                             """Whether to upsample depth map to input resolution before the refinement network.""")
 tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
                             """Whether or not to concatenate the confidence map as an input channel to refinement network""")
@@ -78,21 +78,23 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
 tf.app.flags.DEFINE_bool('visualize', True,
                          """If visualize is true, the inference script will write some auxiliary files for visualization and debugging purposes.
                          This is useful when developing and debugging, but should probably be turned off in production""")
-tf.app.flags.DEFINE_bool('wandb', False,
+tf.app.flags.DEFINE_bool('wandb', True,
                          """Whether or not to log inference results to wandb""")
-tf.app.flags.DEFINE_bool('benchmark', False,
+tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.
                          This should only be used if the input_dir contains GT depth maps""")
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be 
                           set to False by default and is switched on or off by individual methods""")
+tf.app.flags.DEFINE_integer('max_clusters_per_session', 40,
+                            """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 
 
 def setup_data_iterator(input_dir):
     "Configures the data generator that is used to feed batches of data for inference"
     data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height,
-                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='test', benchmark=FLAGS.benchmark, output_scale=FLAGS.sample_scale)
+                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='test', benchmark=FLAGS.benchmark, output_scale=FLAGS.sample_scale, max_clusters_per_session=FLAGS.max_clusters_per_session)
     mvs_generator = iter(data_gen)
     sample_size = len(data_gen.train_clusters)
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -102,7 +102,7 @@ def setup_data_iterator(input_dir):
 
     if FLAGS.benchmark:
         generator_data_type=(tf.float32, tf.float32,
-                               tf.float32, tf.float32, tf.float32, tf.int32)
+                               tf.float32, tf.float32, tf.float32, tf.int32, tf.string)
     else:
         generator_data_type = (tf.float32, tf.float32,
                                tf.float32, tf.float32, tf.int32)
@@ -306,7 +306,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
     FLAGS.benchmark = True
     output_dir = init_inference(input_dir, output_dir, width, height)
     mvs_iterator, sample_size = setup_data_iterator(input_dir)
-    scaled_images, full_images, scaled_cams, full_cams, full_depth, image_index = mvs_iterator.get_next()
+    scaled_images, full_images, scaled_cams, full_cams, full_depth, image_index, session_dir = mvs_iterator.get_next()
 
     depth_start, depth_end, depth_interval, depth_num = set_shapes(
         scaled_images, full_images, scaled_cams, full_cams)
@@ -328,7 +328,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
             start_time = time.time()
             out_residual_depth_map = None
             fetches = [depth_map, prob_map, scaled_images,
-                       scaled_cams, full_cams, full_images, image_index]
+                       scaled_cams, full_cams, full_images, image_index, session_dir]
             # If the network didn't upsample output depth map to full resolution, then we upsample here so that we can benchmark
             # the depth map against the full resolution GT depth map
             full_depth_shape = tf.shape(full_depth)
@@ -343,7 +343,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
             try:
                 if FLAGS.refinement:
                     fetches.append(residual_depth_map)
-                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_loss, out_less_one, out_less_three, out_residual_depth_map = sess.run(
+                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_session_dir, out_loss, out_less_one, out_less_three, out_residual_depth_map = sess.run(
                         fetches)
                 else:
                     out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_loss, out_less_one, out_less_three = sess.run(
@@ -351,7 +351,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
             except tf.errors.OutOfRangeError:
                 print("all dense finished")  # ==> "End of dataset"
                 break
-            print(Notify.INFO, 'depth inference %d/%d finished. (%.3f sec/step)' % (step, sample_size, time.time() - start_time),
+            print(Notify.INFO, 'depth inference %d/%d finished. Image index %d. (%.3f sec/step)' % (step, sample_size, out_index, time.time() - start_time),
                   Notify.ENDC)
             logger.debug(
                 'Performed inference for reference image {}'.format(out_index))
@@ -361,7 +361,11 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
                 out_index, out_less_one))
             logger.info('Image {} less three = {}'.format(
                 out_index, out_less_three))
-            write_output(output_dir, out_depth_map, out_prob_map, out_images,
+
+            write_dir = os.path.join(str(out_session_dir[0]), 'depths_mvsnet') 
+            mu.mkdir_p(write_dir)
+            print('writing output to {}'.format(write_dir))
+            write_output(write_dir, out_depth_map, out_prob_map, out_images,
                          out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
             losses.append(out_loss)
             less_ones.append(out_less_one)
@@ -385,16 +389,8 @@ def main(_):  # pylint: disable=unused-argument
         losses = []
         less_ones = []
         less_threes = []
-        if True:
-            benchmark_depth_maps(FLAGS.input_dir, losses,
-                                 less_ones, less_threes)
-        else:
-            for f in sub_dirs:
-                data_dir = os.path.join(FLAGS.input_dir, f)
-                logger.info(
-                    'Benchmarking depth maps on dir {}'.format(data_dir))
-                benchmark_depth_maps(data_dir, losses, less_ones, less_threes)
-                tf.app.flags.FLAGS.reuse_vars = True
+        benchmark_depth_maps(FLAGS.input_dir, losses,
+                                less_ones, less_threes)
         avg_loss = np.asarray(losses).mean()
         avg_less_one = np.asarray(less_ones).mean()
         avg_less_three = np.asarray(less_threes).mean()

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -60,13 +60,13 @@ tf.app.flags.DEFINE_bool('adaptive_scaling', True,
 # network architecture
 tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method, including '3DCNNs' and 'GRU'""")
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', None,
                             """Whether to apply depth map refinement for MVSNet""")
 tf.app.flags.DEFINE_bool('inverse_depth', False,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-tf.app.flags.DEFINE_string('refinement_network', 'unet',
+tf.app.flags.DEFINE_string('refinement_network', None,
                            """Specifies network to use for refinement. One of 'original' or 'unet'.
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
@@ -88,7 +88,7 @@ tf.app.flags.DEFINE_bool('write_output', False,
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")
-tf.app.flags.DEFINE_integer('max_clusters_per_session', 2,
+tf.app.flags.DEFINE_integer('max_clusters_per_session', 4,
                             """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,9 +38,9 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 4,
+tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
 tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,13 +38,13 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 8,
+tf.app.flags.DEFINE_integer('view_num', 4,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 256,
+tf.app.flags.DEFINE_integer('max_d', 32,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 1024,
+tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 768,
+tf.app.flags.DEFINE_integer('height', 384,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -91,8 +91,9 @@ FLAGS = tf.app.flags.FLAGS
 
 def setup_data_iterator(input_dir):
     "Configures the data generator that is used to feed batches of data for inference"
+    mode = 'benchmark' if FLAGS.benchmark else 'test'
     data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height,
-                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='test', benchmark=FLAGS.benchmark, output_scale=FLAGS.sample_scale)
+                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode=mode, benchmark=FLAGS.benchmark, output_scale=FLAGS.sample_scale)
     mvs_generator = iter(data_gen)
     sample_size = len(data_gen.train_clusters)
 
@@ -118,7 +119,8 @@ def setup_output_dir(input_dir, output_dir):
     if output_dir is None:
         output_dir = os.path.join(input_dir, 'depths_mvsnet')
     mu.mkdir_p(output_dir)
-    logger.info('Running inference on {} and writing output to {}'.format(input_dir, output_dir))
+    logger.info('Running inference on {} and writing output to {}'.format(
+        input_dir, output_dir))
     return output_dir
 
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -60,7 +60,7 @@ tf.app.flags.DEFINE_bool('adaptive_scaling', True,
 # network architecture
 tf.app.flags.DEFINE_string('regularization', '3DCNNs',
                            """Regularization method, including '3DCNNs' and 'GRU'""")
-tf.app.flags.DEFINE_boolean('refinement', True,
+tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for MVSNet""")
 tf.app.flags.DEFINE_bool('inverse_depth', False,
                          """Whether to apply inverse depth for R-MVSNet""")
@@ -327,6 +327,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
     # init option
     var_init_op = tf.local_variables_initializer()
     init_op, config = mu.init_session()
+    out_residual_depth_map = None
 
     with tf.Session(config=config) as sess:
         # initialization
@@ -341,7 +342,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
                     out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_session_dir, out_loss, out_less_one, out_less_three, out_residual_depth_map = sess.run(
                         [depth_map, prob_map, scaled_images, scaled_cams, full_cams, full_images, image_index, session_dir, loss, less_one_accuracy, less_three_accuracy, residual_depth_map])
                 else:
-                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_loss, out_less_one, out_less_three = sess.run(
+                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_session_dir, out_loss, out_less_one, out_less_three = sess.run(
                         [depth_map, prob_map, scaled_images, scaled_cams, full_cams, full_images, image_index, session_dir, loss, less_one_accuracy, less_three_accuracy])
             except tf.errors.OutOfRangeError:
                 print("all dense finished")  # ==> "End of dataset"

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -94,8 +94,9 @@ FLAGS = tf.app.flags.FLAGS
 def setup_data_iterator(input_dir):
     "Configures the data generator that is used to feed batches of data for inference"
     mode = 'benchmark' if FLAGS.benchmark else 'test'
+    print(mode)
     data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height, FLAGS.max_d, FLAGS.interval_scale, \
-                FLAGS.base_image_size, mode = 'test', benchmark = FLAGS.benchmark, output_scale = FLAGS.sample_scale, max_clusters_per_session = FLAGS.max_clusters_per_session)
+                FLAGS.base_image_size, mode = mode, val_split = 0.0,  benchmark = FLAGS.benchmark, output_scale = FLAGS.sample_scale, max_clusters_per_session = FLAGS.max_clusters_per_session)
     mvs_generator=iter(data_gen)
     sample_size=len(data_gen.train_clusters)
 
@@ -384,7 +385,7 @@ def main(_):  # pylint: disable=unused-argument
         losses = []
         less_ones = []
         less_threes = []
-        if run_dir:
+        if True:
             benchmark_depth_maps(FLAGS.input_dir, losses,
                                  less_ones, less_threes)
         else:

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,13 +38,13 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 8,
+tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 256,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 1024,
+tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 768,
+tf.app.flags.DEFINE_integer('height', 480,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -69,7 +69,7 @@ tf.app.flags.DEFINE_string('network_mode', 'normal',
 tf.app.flags.DEFINE_string('refinement_network', 'unet',
                            """Specifies network to use for refinement. One of 'original' or 'unet'.
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
-tf.app.flags.DEFINE_boolean('upsample_before_refinement', False,
+tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
                             """Whether to upsample depth map to input resolution before the refinement network.""")
 tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
                             """Whether or not to concatenate the confidence map as an input channel to refinement network""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -42,9 +42,9 @@ tf.app.flags.DEFINE_integer('view_num', 4,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 640,
+tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 480,
+tf.app.flags.DEFINE_integer('height', 384,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -82,12 +82,11 @@ tf.app.flags.DEFINE_bool('wandb', False,
                          """Whether or not to log inference results to wandb""")
 tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.
-                         This should only be used if the input_dir contains GT depth maps. If benchmark is True, the expected input_dir format consists of multiple
-                         sessions rather than a single session. """)
+                         This should only be used if the input_dir contains GT depth maps""")
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")
-tf.app.flags.DEFINE_integer('max_clusters_per_session', None,
+tf.app.flags.DEFINE_integer('max_clusters_per_session', 20,
                             """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 
@@ -103,7 +102,7 @@ def setup_data_iterator(input_dir):
 
     if FLAGS.benchmark:
         generator_data_type=(tf.float32, tf.float32,
-                               tf.float32, tf.float32, tf.float32, tf.int32, tf.string)
+                               tf.float32, tf.float32, tf.float32, tf.int32)
     else:
         generator_data_type = (tf.float32, tf.float32,
                                tf.float32, tf.float32, tf.int32)
@@ -297,8 +296,7 @@ def compute_depth_maps(input_dir, output_dir=None, width=None, height=None):
                 break
             print(Notify.INFO, 'depth inference %d/%d finished. Image index %d. (%.3f sec/step)' % (step, sample_size, out_index, time.time() - start_time),
                   Notify.ENDC)
-
-            write_output(write_dir, out_depth_map, out_prob_map, out_images,
+            write_output(output_dir, out_depth_map, out_prob_map, out_images,
                          out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
 
 
@@ -308,7 +306,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
     FLAGS.benchmark = True
     output_dir = init_inference(input_dir, output_dir, width, height)
     mvs_iterator, sample_size = setup_data_iterator(input_dir)
-    scaled_images, full_images, scaled_cams, full_cams, full_depth, image_index, session_dir = mvs_iterator.get_next()
+    scaled_images, full_images, scaled_cams, full_cams, full_depth, image_index = mvs_iterator.get_next()
 
     depth_start, depth_end, depth_interval, depth_num = set_shapes(
         scaled_images, full_images, scaled_cams, full_cams)
@@ -330,7 +328,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
             start_time = time.time()
             out_residual_depth_map = None
             fetches = [depth_map, prob_map, scaled_images,
-                       scaled_cams, full_cams, full_images, image_index, session_dir ]
+                       scaled_cams, full_cams, full_images, image_index]
             # If the network didn't upsample output depth map to full resolution, then we upsample here so that we can benchmark
             # the depth map against the full resolution GT depth map
             full_depth_shape = tf.shape(full_depth)
@@ -345,15 +343,15 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
             try:
                 if FLAGS.refinement:
                     fetches.append(residual_depth_map)
-                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_session_dir, out_loss, out_less_one, out_less_three, out_residual_depth_map = sess.run(
+                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_loss, out_less_one, out_less_three, out_residual_depth_map = sess.run(
                         fetches)
                 else:
-                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_session_dir, out_loss, out_less_one, out_less_three = sess.run(
+                    out_depth_map, out_prob_map, out_images, out_cams, out_full_cams, out_full_images, out_index, out_loss, out_less_one, out_less_three = sess.run(
                         fetches)
             except tf.errors.OutOfRangeError:
                 print("all dense finished")  # ==> "End of dataset"
                 break
-            print(Notify.INFO, 'depth inference %d/%d finished. Image index %d. (%.3f sec/step)' % (step, sample_size, out_index, time.time() - start_time),
+            print(Notify.INFO, 'depth inference %d/%d finished. (%.3f sec/step)' % (step, sample_size, time.time() - start_time),
                   Notify.ENDC)
             logger.debug(
                 'Performed inference for reference image {}'.format(out_index))
@@ -363,10 +361,7 @@ def benchmark_depth_maps(input_dir, losses, less_ones, less_threes, output_dir=N
                 out_index, out_less_one))
             logger.info('Image {} less three = {}'.format(
                 out_index, out_less_three))
-            write_dir = os.path.join(str(out_session_dir[0]), 'depths_mvsnet')
-            logger.info('Writing output to dir {}'.format(write_dir))
-            mu.mkdir_p(write_dir)
-            write_output(write_dir, out_depth_map, out_prob_map, out_images,
+            write_output(output_dir, out_depth_map, out_prob_map, out_images,
                          out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
             losses.append(out_loss)
             less_ones.append(out_less_one)
@@ -390,8 +385,16 @@ def main(_):  # pylint: disable=unused-argument
         losses = []
         less_ones = []
         less_threes = []
-        benchmark_depth_maps(FLAGS.input_dir, losses,
-                                less_ones, less_threes)
+        if True:
+            benchmark_depth_maps(FLAGS.input_dir, losses,
+                                 less_ones, less_threes)
+        else:
+            for f in sub_dirs:
+                data_dir = os.path.join(FLAGS.input_dir, f)
+                logger.info(
+                    'Benchmarking depth maps on dir {}'.format(data_dir))
+                benchmark_depth_maps(data_dir, losses, less_ones, less_threes)
+                tf.app.flags.FLAGS.reuse_vars = True
         avg_loss = np.asarray(losses).mean()
         avg_less_one = np.asarray(less_ones).mean()
         avg_less_three = np.asarray(less_threes).mean()

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -40,11 +40,11 @@ tf.app.flags.DEFINE_string('run_name', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 4,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 32,
+tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when testing.""")
-tf.app.flags.DEFINE_integer('width', 512,
+tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 384,
+tf.app.flags.DEFINE_integer('height', 480,
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")
@@ -66,7 +66,7 @@ tf.app.flags.DEFINE_bool('inverse_depth', False,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-tf.app.flags.DEFINE_string('refinement_network', 'original',
+tf.app.flags.DEFINE_string('refinement_network', 'unet',
                            """Specifies network to use for refinement. One of 'original' or 'unet'.
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
@@ -78,7 +78,7 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
 tf.app.flags.DEFINE_bool('visualize', True,
                          """If visualize is true, the inference script will write some auxiliary files for visualization and debugging purposes.
                          This is useful when developing and debugging, but should probably be turned off in production""")
-tf.app.flags.DEFINE_bool('wandb', True,
+tf.app.flags.DEFINE_bool('wandb', False,
                          """Whether or not to log inference results to wandb""")
 tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.
@@ -86,7 +86,7 @@ tf.app.flags.DEFINE_bool('benchmark', True,
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")
-tf.app.flags.DEFINE_integer('max_clusters_per_session', 40,
+tf.app.flags.DEFINE_integer('max_clusters_per_session', None,
                             """The maximum number of clusters to benchmark per session. If not benchmarking this should probably be set to None""")
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -31,16 +31,16 @@ tf.app.flags.DEFINE_string('input_dir', None,
 tf.app.flags.DEFINE_string('output_dir', None,
                            """Path to data to dir to output results""")
 tf.app.flags.DEFINE_string('model_dir',
-                           'gs://mvs-training-mlengine/a_main_unet_v4_refine/models/',
+                           'gs://mvs-training-mlengine/a_main_v6_4gpu_refine_from_490000_lr_001/models/',
                            """Path to restore the model.""")
-tf.app.flags.DEFINE_integer('ckpt_step', 55000,
+tf.app.flags.DEFINE_integer('ckpt_step', 515000,
                             """ckpt  step.""")
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 4,
+tf.app.flags.DEFINE_integer('view_num', 6,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when testing.""")
 tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
@@ -66,7 +66,7 @@ tf.app.flags.DEFINE_bool('inverse_depth', False,
                          """Whether to apply inverse depth for R-MVSNet""")
 tf.app.flags.DEFINE_string('network_mode', 'normal',
                            """One of 'normal', 'lite' or 'ultralite'. If 'lite' or 'ultralite' then networks have fewer params""")
-tf.app.flags.DEFINE_string('refinement_network', 'unet',
+tf.app.flags.DEFINE_string('refinement_network', 'original',
                            """Specifies network to use for refinement. One of 'original' or 'unet'.
                             If 'original' then the original mvsnet refinement network is used, otherwise a unet style architecture is used.""")
 tf.app.flags.DEFINE_boolean('upsample_before_refinement', True,
@@ -78,7 +78,7 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
 tf.app.flags.DEFINE_bool('visualize', True,
                          """If visualize is true, the inference script will write some auxiliary files for visualization and debugging purposes.
                          This is useful when developing and debugging, but should probably be turned off in production""")
-tf.app.flags.DEFINE_bool('wandb', False,
+tf.app.flags.DEFINE_bool('wandb', True,
                          """Whether or not to log inference results to wandb""")
 tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -94,14 +94,8 @@ FLAGS = tf.app.flags.FLAGS
 def setup_data_iterator(input_dir):
     "Configures the data generator that is used to feed batches of data for inference"
     mode = 'benchmark' if FLAGS.benchmark else 'test'
-    data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height,
-<< << << < HEAD
-                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode=mode, benchmark=FLAGS.benchmark, output_scale=FLAGS.sample_scale)
-
-
-== == == =
-                                FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode = 'test', benchmark = FLAGS.benchmark, output_scale = FLAGS.sample_scale, max_clusters_per_session = FLAGS.max_clusters_per_session)
->> >>>> > 622f635927229ab94be88ed331b59a392efc5d6c
+    data_gen = ClusterGenerator(input_dir, FLAGS.view_num, FLAGS.width, FLAGS.height, FLAGS.max_d, FLAGS.interval_scale, \
+                FLAGS.base_image_size, mode = 'test', benchmark = FLAGS.benchmark, output_scale = FLAGS.sample_scale, max_clusters_per_session = FLAGS.max_clusters_per_session)
     mvs_generator=iter(data_gen)
     sample_size=len(data_gen.train_clusters)
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -82,7 +82,8 @@ tf.app.flags.DEFINE_bool('wandb', True,
                          """Whether or not to log inference results to wandb""")
 tf.app.flags.DEFINE_bool('benchmark', True,
                          """If benchmark is True, the network results will be benchmarked against GT.
-                         This should only be used if the input_dir contains GT depth maps""")
+                         This should only be used if the input_dir contains GT depth maps. If benchmark is True, the expected input_dir format consists of multiple
+                         sessions rather than a single session. """)
 tf.app.flags.DEFINE_bool('reuse_vars', False,
                          """A global flag representing whether variables should be reused. This should be
                           set to False by default and is switched on or off by individual methods""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -38,23 +38,13 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 # input parameters
-<<<<<<< HEAD
-tf.app.flags.DEFINE_integer('view_num', 6,
-=======
 tf.app.flags.DEFINE_integer('view_num', 4,
->>>>>>> 275d9182056f1260aedeb24e38ebe166de6568d3
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 32,
                             """Maximum depth step when testing.""")
-<<<<<<< HEAD
-tf.app.flags.DEFINE_integer('width', 640,
-                            """Maximum image width when testing.""")
-tf.app.flags.DEFINE_integer('height', 480,
-=======
 tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when testing.""")
 tf.app.flags.DEFINE_integer('height', 384,
->>>>>>> 275d9182056f1260aedeb24e38ebe166de6568d3
                             """Maximum image height when testing.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume (W and H).""")

--- a/mvsnet/loss.py
+++ b/mvsnet/loss.py
@@ -59,11 +59,11 @@ def less_three_percentage(y_true, y_pred, interval):
     return tf.reduce_sum(less_three_image) / denom
 
 
-def mvsnet_regression_loss(estimated_depth_image, depth_image, depth_interval, benchmark=False, depth_start=None, depth_end=None):
+def mvsnet_regression_loss(estimated_depth_image, depth_image, depth_start, depth_end):
     """ compute loss and accuracy """
-    # If we are benchmarking, we use a fixed depth interval that is independent of the depth_num
-    if benchmark:
-        depth_interval = tf.div(depth_end-depth_start, 191.0)
+    # For loss and accuracy we use a depth_interval that is independent of the number of depth buckets
+    # so we can easily compare results for various depth_num. We divide by 191 for historical reasons.
+    depth_interval = tf.div(depth_end-depth_start, 191.0)
     # non zero mean absulote loss
     masked_mae = non_zero_mean_absolute_diff(
         depth_image, estimated_depth_image, depth_interval)

--- a/mvsnet/loss.py
+++ b/mvsnet/loss.py
@@ -59,8 +59,11 @@ def less_three_percentage(y_true, y_pred, interval):
     return tf.reduce_sum(less_three_image) / denom
 
 
-def mvsnet_regression_loss(estimated_depth_image, depth_image, depth_interval):
+def mvsnet_regression_loss(estimated_depth_image, depth_image, depth_interval, benchmark=False, depth_start=None, depth_end=None):
     """ compute loss and accuracy """
+    # If we are benchmarking, we use a fixed depth interval that is independent of the depth_num
+    if benchmark:
+        depth_interval = tf.div(depth_end-depth_start, 191.0)
     # non zero mean absulote loss
     masked_mae = non_zero_mean_absolute_diff(
         depth_image, estimated_depth_image, depth_interval)

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -17,7 +17,7 @@ logger = setup_logger('mvsnet.cnn_wrapper.model')
 FLAGS = tf.app.flags.FLAGS
 
 
-def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=2):
+def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=4):
     """ get probability map from cost volume 
     The probability map is computed by summing the probabilities of the four depth slices int he cost volume that are closest
     to the predicted depth ~ this is a simple measure of confidence that works well for downstream tasks like fusion.

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -17,7 +17,7 @@ logger = setup_logger('mvsnet.cnn_wrapper.model')
 FLAGS = tf.app.flags.FLAGS
 
 
-def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=4):
+def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=2):
     """ get probability map from cost volume 
     The probability map is computed by summing the probabilities of the four depth slices int he cost volume that are closest
     to the predicted depth ~ this is a simple measure of confidence that works well for downstream tasks like fusion.

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -253,7 +253,7 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
         tf.slice(cams, [0, 0, 0, 0, 0], [-1, 1, 2, 4, 4]), axis=1)
 
     # image feature extraction
-    reuse = not is_master_gpu
+    reuse = tf.app.flags.FLAGS.reuse_vars #not is_master_gpu
     ref_tower = UNetDS2GN({'data': ref_image}, trainable=trainable,
                           training=training, mode=network_mode, reuse=reuse)
     base_divisor = ref_tower.base_divisor
@@ -652,6 +652,8 @@ def depth_refine(init_depth_map, image, prob_map, depth_num, depth_start, depth_
             [data, stereo_image], axis=3)
     # refinement network
     reuse = not is_master_gpu
+    if tf.app.flags.FLAGS.reuse_vars:
+        reuse = True
     if network_type == 'unet':
         norm_depth_tower = RefineUNetConv({'color_image': image, 'depth_image': data},
                                         trainable=trainable, training=training, mode=network_mode, reuse=reuse)

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -26,7 +26,7 @@ the case of training, validation or benchmarking.
 
 class ClusterGenerator:
     def __init__(self, sessions_dir, view_num=3, image_width=1024, image_height=768, depth_num=256,
-                 interval_scale=1, base_image_size=1, include_empty=False, mode='training', val_split=0.1, rescaling=True, output_scale=0.25, flip_cams=True, sessions_frac=1.0, benchmark=False, max_clusters_per_session = None):
+                 interval_scale=1, base_image_size=1, include_empty=False, mode='training', val_split=0.1, rescaling=True, output_scale=0.25, flip_cams=True, sessions_frac=1.0, benchmark=False, max_clusters_per_session=None):
         self.logger = setup_logger('ClusterGenerator')
         self.sessions_dir = sessions_dir
         self.view_num = view_num
@@ -49,7 +49,7 @@ class ClusterGenerator:
         # The sessions_fraction [0,1] is the fraction of all available sessions in sessions_dir
         self.sessions_frac = sessions_frac
         self.benchmark = benchmark
-        # max clusters per session is used if you don't want to train on all the clusters in a session 
+        # max clusters per session is used if you don't want to train on all the clusters in a session
         self.max_clusters_per_session = max_clusters_per_session
         self.parse_sessions()
         self.set_iter_clusters()
@@ -160,6 +160,9 @@ class ClusterGenerator:
         elif self.mode == 'validation':
             self.iter_clusters = val_clusters
         elif self.mode == 'test':
+            # If we are testing, the val_split is zero, and we test on the all clusters (ignore the naming as train)
+            self.iter_clusters = train_clusters
+        elif self.mode == 'benchmark':
             # If we are testing, the val_split is zero, and we test on the all clusters (ignore the naming as train)
             self.iter_clusters = train_clusters
         else:

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -127,7 +127,8 @@ class ClusterGenerator:
         train_clusters = self.clusters[val_end:]
         val_clusters = self.clusters[:val_end]
         # We shuffle the train and val clusters separately, so they don't mix
-        random.shuffle(train_clusters)
+        if self.mode != 'test':
+            random.shuffle(train_clusters)
         random.shuffle(val_clusters)
         if self.mode == 'test':
             self.logger.info(" {} clusters will be used for testing".format(
@@ -244,7 +245,7 @@ class ClusterGenerator:
                         depth = c.masked_reference_depth()
                         images, cams, depth = ut.scale_mvs_input(
                             images, cams, depth, c.rescale)
-                        images, cams, depth = ut.crop_mvs_input(
+                        cropped_images, cropped_cams, depth = ut.crop_mvs_input(
                             images, cams, self.image_width, self.image_height, self.base_image_size, depth)
                         depth = ut.reshape_depth(depth)
 

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -132,7 +132,7 @@ class ClusterGenerator:
         """
         seed = 5  # We shuffle with the same random seed so that training stays in training
         # and validation stays in validation. We don't shuffle on inference
-        if self.mode != 'test':
+        if self.mode != 'test' and self.mode != 'benchmark':
             random.Random(seed).shuffle(self.clusters)
         num = len(self.clusters)
         val_end = int(num*self.val_split)
@@ -140,10 +140,10 @@ class ClusterGenerator:
         train_clusters = self.clusters[val_end:]
         val_clusters = self.clusters[:val_end]
         # We shuffle the train and val clusters separately, so they don't mix
-        if self.mode != 'test':
+        if self.mode != 'test' and self.mode != 'benchmark':
             random.shuffle(train_clusters)
-        random.shuffle(val_clusters)
-        if self.mode == 'test':
+            random.shuffle(val_clusters)
+        if self.mode == 'test' or self.mode == 'benchmark':
             self.logger.info(" {} clusters will be used for testing".format(
                 len(train_clusters)))
         else:
@@ -293,6 +293,6 @@ class ClusterGenerator:
                     self.logger.debug('image index: {}'.format(image_index))
 
                     if self.benchmark:
-                        yield (output_images, input_images, output_cams, full_cams, depth, image_index)
+                        yield (output_images, input_images, output_cams, full_cams, depth, image_index, c.session_dir)
                     else:
                         yield (output_images, input_images, output_cams, full_cams, image_index)

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -86,7 +86,12 @@ class ClusterGenerator:
             # generator from needing to load all of the clusters. In fact we might just want to do lazy loading of clusters
             for s, session in enumerate(sessions[:num_sessions]):
                 session_dir = os.path.join(self.sessions_dir, session)
-                self.load_clusters(session_dir, clusters)
+                self.logger.debug('Parsing session dir {}'.format(session_dir))
+                try:
+                    self.load_clusters(session_dir, clusters)
+                except Exception as e:
+                    self.logger.debug(
+                        'Failed to load clusters for session dir {} with exception {}'.format(session_dir, e))
                 if s % 25 == 0:
                     self.logger.info(
                         'Parsed {} / {} sessions'.format(s, num_sessions))
@@ -244,7 +249,7 @@ class ClusterGenerator:
             output_cams: Numpy array of camera data that has been reformatted to match the output size of network
             image_index: The index of the reference image used for this cluster
         """
-        if self.mode == 'test':
+        if self.mode == 'test' or self.mode == 'benchmark':
             while True:
                 for c in self.iter_clusters:
                     start = time.time()

--- a/mvsnet/preprocess.py
+++ b/mvsnet/preprocess.py
@@ -208,7 +208,7 @@ def write_reference_image(image, file_path):
         wandb.log({"reference_images": wandb.Image(
             image, caption=file_path)})
 
-def write_residual_depth_map(image, file_path, exp=0.35):
+def write_residual_depth_map(image, file_path, exp=0.5):
     """ Writes an inverted depth map for visualization purposes
     args:
         image: Depth image to write

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 4,
+tf.app.flags.DEFINE_integer('view_num', 5,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 32,
+tf.app.flags.DEFINE_integer('max_d', 192,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 640,
                             """Maximum image width when training.""")
@@ -74,7 +74,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'main_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -96,11 +96,11 @@ tf.app.flags.DEFINE_integer('batch_size', 1,
                             """Training batch size.""")
 tf.app.flags.DEFINE_integer('epoch', None,
                             """Training epoch number.""")
-tf.app.flags.DEFINE_float('base_lr', 0.0001,
+tf.app.flags.DEFINE_float('base_lr', 0.0005,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', None,
+tf.app.flags.DEFINE_integer('stepvalue', 40000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")
@@ -110,13 +110,13 @@ tf.app.flags.DEFINE_float('val_batch_size', 10,
                           """Number of images to run validation on when validation.""")
 tf.app.flags.DEFINE_float('train_steps_per_val', 100,
                           """Number of samples to train on before running a round of validation.""")
-tf.app.flags.DEFINE_float('dataset_fraction', 0.1,
+tf.app.flags.DEFINE_float('dataset_fraction', 1.0,
                           """Fraction of dataset to use for training. Float between 0 and 1. NOTE: For training a production model
                            you should use 1, but for experiments it may be useful to use a fraction less than 1.""")
 tf.app.flags.DEFINE_float('decay_per_10_epoch', 0.01,
                           """ The fraction by which learning rate should decay every 10 epochs""")
 tf.app.flags.DEFINE_bool('wandb', True,
-                         """Whether or not to log inference results to wandb""")
+                         """Whether or not to log results to wandb""")
 
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -96,11 +96,11 @@ tf.app.flags.DEFINE_integer('batch_size', 1,
                             """Training batch size.""")
 tf.app.flags.DEFINE_integer('epoch', None,
                             """Training epoch number.""")
-tf.app.flags.DEFINE_float('base_lr', 0.00005,
+tf.app.flags.DEFINE_float('base_lr', 0.00025,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', 70000,
+tf.app.flags.DEFINE_integer('stepvalue', 90000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -33,7 +33,7 @@ logger = mu.setup_logger('mvsnet-train')
 # params for datasets
 tf.app.flags.DEFINE_string('train_data_root', None,
                            """Path to dtu dataset.""")
-tf.app.flags.DEFINE_string('log_dir', None,
+tf.app.flags.DEFINE_string('logs_dir', None,
                            """Path to store the log.""")
 tf.app.flags.DEFINE_string('model_dir', None,
                            """Path to save the model.""")
@@ -53,7 +53,7 @@ tf.app.flags.DEFINE_string('run_name', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 5,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 128,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when training.""")
@@ -100,7 +100,7 @@ tf.app.flags.DEFINE_float('base_lr', 0.001,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', 30000,
+tf.app.flags.DEFINE_integer('stepvalue', 40000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")
@@ -110,7 +110,7 @@ tf.app.flags.DEFINE_float('val_batch_size', 10,
                           """Number of images to run validation on when validation.""")
 tf.app.flags.DEFINE_float('train_steps_per_val', 100,
                           """Number of samples to train on before running a round of validation.""")
-tf.app.flags.DEFINE_float('dataset_fraction', 0.2,
+tf.app.flags.DEFINE_float('dataset_fraction', 1.0,
                           """Fraction of dataset to use for training. Float between 0 and 1. NOTE: For training a production model
                            you should use 1, but for experiments it may be useful to use a fraction less than 1.""")
 tf.app.flags.DEFINE_float('decay_per_10_epoch', 0.01,
@@ -275,7 +275,7 @@ def initialize_trainer():
 
     # Prepare validation summary 
     val_sum_file = os.path.join(
-        FLAGS.log_dir, 'validation_summary-{}.txt'.format(train_session_start))
+        FLAGS.logs_dir, 'validation_summary-{}.txt'.format(train_session_start))
     with file_io.FileIO(val_sum_file, 'w+') as f:
         header = 'train_step,val_loss,val_less_one,val_less_three\n'
         f.write(header)

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,7 +51,7 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 5,
+tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 128,
                             """Maximum depth step when training.""")
@@ -89,8 +89,6 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
                             """Whether or not to concatenate the confidence map as an input channel to refinement network""")
 tf.app.flags.DEFINE_boolean('refine_with_stereo', False,
                             """Whether or not to inject a stereo partner into refinement network""")
-tf.app.flags.DEFINE_integer('num_cost_buckets', False,
-                            """Whether or not to inject a stereo partner into refinement network""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,
                             """Number of GPUs.""")
@@ -98,11 +96,11 @@ tf.app.flags.DEFINE_integer('batch_size', 1,
                             """Training batch size.""")
 tf.app.flags.DEFINE_integer('epoch', None,
                             """Training epoch number.""")
-tf.app.flags.DEFINE_float('base_lr', 0.001,
+tf.app.flags.DEFINE_float('base_lr', 0.00005,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', 40000,
+tf.app.flags.DEFINE_integer('stepvalue', 50000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -74,7 +74,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'main_only',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -96,11 +96,11 @@ tf.app.flags.DEFINE_integer('batch_size', 1,
                             """Training batch size.""")
 tf.app.flags.DEFINE_integer('epoch', None,
                             """Training epoch number.""")
-tf.app.flags.DEFINE_float('base_lr', 0.0005,
+tf.app.flags.DEFINE_float('base_lr', 0.001,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', 40000,
+tf.app.flags.DEFINE_integer('stepvalue', 30000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -110,7 +110,7 @@ tf.app.flags.DEFINE_float('val_batch_size', 10,
                           """Number of images to run validation on when validation.""")
 tf.app.flags.DEFINE_float('train_steps_per_val', 100,
                           """Number of samples to train on before running a round of validation.""")
-tf.app.flags.DEFINE_float('dataset_fraction', 1.0,
+tf.app.flags.DEFINE_float('dataset_fraction', 0.2,
                           """Fraction of dataset to use for training. Float between 0 and 1. NOTE: For training a production model
                            you should use 1, but for experiments it may be useful to use a fraction less than 1.""")
 tf.app.flags.DEFINE_float('decay_per_10_epoch', 0.01,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -74,7 +74,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'main_only',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -110,7 +110,7 @@ tf.app.flags.DEFINE_float('val_batch_size', 10,
                           """Number of images to run validation on when validation.""")
 tf.app.flags.DEFINE_float('train_steps_per_val', 100,
                           """Number of samples to train on before running a round of validation.""")
-tf.app.flags.DEFINE_float('dataset_fraction', 0.2,
+tf.app.flags.DEFINE_float('dataset_fraction', 1.0,
                           """Fraction of dataset to use for training. Float between 0 and 1. NOTE: For training a production model
                            you should use 1, but for experiments it may be useful to use a fraction less than 1.""")
 tf.app.flags.DEFINE_float('decay_per_10_epoch', 0.01,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -108,9 +108,9 @@ tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")
 tf.app.flags.DEFINE_float('gamma', 0.5,
                           """Learning rate decay rate.""")
-tf.app.flags.DEFINE_float('val_batch_size', 10,
+tf.app.flags.DEFINE_float('val_batch_size', 50,
                           """Number of images to run validation on when validation.""")
-tf.app.flags.DEFINE_float('train_steps_per_val', 100,
+tf.app.flags.DEFINE_float('train_steps_per_val', 500,
                           """Number of samples to train on before running a round of validation.""")
 tf.app.flags.DEFINE_float('dataset_fraction', 1.0,
                           """Fraction of dataset to use for training. Float between 0 and 1. NOTE: For training a production model

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -89,6 +89,8 @@ tf.app.flags.DEFINE_boolean('refine_with_confidence', True,
                             """Whether or not to concatenate the confidence map as an input channel to refinement network""")
 tf.app.flags.DEFINE_boolean('refine_with_stereo', False,
                             """Whether or not to inject a stereo partner into refinement network""")
+tf.app.flags.DEFINE_integer('num_cost_buckets', False,
+                            """Whether or not to inject a stereo partner into refinement network""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,
                             """Number of GPUs.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -55,9 +55,9 @@ tf.app.flags.DEFINE_integer('view_num', 5,
                             """Number of images (1 ref image and view_num - 1 view images).""")
 tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when training.""")
-tf.app.flags.DEFINE_integer('width', 640,
+tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when training.""")
-tf.app.flags.DEFINE_integer('height', 480,
+tf.app.flags.DEFINE_integer('height', 384,
                             """Maximum image height when training.""")
 tf.app.flags.DEFINE_float('sample_scale', 0.25,
                           """Downsample scale for building cost volume.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -100,11 +100,7 @@ tf.app.flags.DEFINE_float('base_lr', 0.00005,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-<<<<<<< HEAD
-tf.app.flags.DEFINE_integer('stepvalue', 50000,
-=======
 tf.app.flags.DEFINE_integer('stepvalue', 70000,
->>>>>>> 275d9182056f1260aedeb24e38ebe166de6568d3
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -51,9 +51,9 @@ tf.app.flags.DEFINE_string('run_name', None,
                            """A name to use for wandb logging""")
 
 # input parameters
-tf.app.flags.DEFINE_integer('view_num', 5,
+tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 64,
+tf.app.flags.DEFINE_integer('max_d', 128,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('width', 512,
                             """Maximum image width when training.""")
@@ -74,7 +74,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum', 'rmsprop' or 'adam' """)
 tf.app.flags.DEFINE_boolean('refinement', True,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('refinement_train_mode', 'refine_only',
+tf.app.flags.DEFINE_string('refinement_train_mode', 'main_only',
                             """One of 'all', 'refine_only' or 'main_only'. If 'main_only' then only the main network is trained,
                             if 'refine_only', only the refinement network is trained, and if 'all' then the whole network is trained.
                             Note this is only applicable if training with refinement=True and 3DCNN regularization """)
@@ -100,7 +100,7 @@ tf.app.flags.DEFINE_float('base_lr', 0.001,
                           """Base learning rate.""")
 tf.app.flags.DEFINE_integer('display', 1,
                             """Interval of loginfo display.""")
-tf.app.flags.DEFINE_integer('stepvalue', 30000,
+tf.app.flags.DEFINE_integer('stepvalue', 70000,
                             """Step interval to decay learning rate.""")
 tf.app.flags.DEFINE_integer('snapshot', 5000,
                             """Step interval to save the model.""")

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -318,15 +318,9 @@ def get_batch(training_iterator, validation_iterator):
 def get_loss(images, cams, depth_image, depth_start, depth_interval, full_depth, depth_end, i):
     """ Performs inference with specified network and return loss function """
     is_master_gpu = True if i == 0 else False
-    #depth_end = depth_start + \
-    #    (tf.cast(depth_num, tf.float32) - 1) * depth_interval
-    #depth_end = tf.reshape(
-    #    tf.slice(scaled_cams, [0, 0, 1, 3, 3], [FLAGS.batch_size, 1, 1, 1, 1]), [FLAGS.batch_size])
-
     # inference
     if FLAGS.regularization == '3DCNNs':
-        #main_trainable = False if FLAGS.refinement_train_mode == 'refine_only' and FLAGS.refinement==True else True
-        main_trainable = True
+        main_trainable = False if FLAGS.refinement_train_mode == 'refine_only' and FLAGS.refinement==True else True
         # initial depth map
         depth_map, prob_map = inference(
             images, cams, FLAGS.max_d, depth_start, depth_interval, FLAGS.network_mode, is_master_gpu, trainable=main_trainable, inverse_depth = FLAGS.inverse_depth)

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -117,6 +117,9 @@ tf.app.flags.DEFINE_float('decay_per_10_epoch', 0.01,
                           """ The fraction by which learning rate should decay every 10 epochs""")
 tf.app.flags.DEFINE_bool('wandb', True,
                          """Whether or not to log results to wandb""")
+tf.app.flags.DEFINE_bool('reuse_vars', False,
+                         """A global flag representing whether variables should be reused. This should be 
+                          set to False by default and is switched on or off by individual methods""")
 
 FLAGS = tf.app.flags.FLAGS
 

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -60,4 +60,4 @@ def initialize_wandb(args, project='mvsnet'):
     else:
         subprocess.call(["wandb", "login", wandb_key])
     wandb.init(project=project, name=args.run_name)
-    wandb.config.update(args)
+    wandb.config.update(args, allow_val_change=True)

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -58,6 +58,9 @@ def initialize_wandb(args, project='mvsnet'):
     if ml_engine():
         subprocess.call(["/root/.local/bin/wandb", "login", wandb_key])
     else:
-        subprocess.call(["wandb", "login", wandb_key])
+        try:
+            subprocess.call(["wandb", "login", wandb_key])
+        except Exception as e:
+            subprocess.call([ "python", "-m", "wandb.cli", "login", wandb_key])
     wandb.init(project=project, name=args.run_name)
     wandb.config.update(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ matplotlib>=1.5
 Pillow>=3.1.2
 nvidia-ml-py
 wandb
+imageioy

--- a/scripts/test_and_fuse.py
+++ b/scripts/test_and_fuse.py
@@ -14,15 +14,13 @@ on the file system.
 def test_and_fuse(args, dense_folder, ply_folder):
     if args.no_test is not True:
         ut.test(dense_folder, args.ckpt_step, args.model_dir)
-        return None
-    if args.test_only is not True:
-        ut.clear_old_points(dense_folder)
-        ut.fuse(dense_folder, args.fusibile_path, args.prob_threshold,
-                args.disp_threshold, args.num_consistent)
-        ply_paths = ut.get_fusion_plys(dense_folder)
-        urls = ut.handle_plys(ply_paths, dense_folder, ply_folder, args)
-        print('Sketchfab url {}'.format(urls))
-        return urls
+    ut.clear_old_points(dense_folder)
+    ut.fuse(dense_folder, args.fusibile_path, args.prob_threshold,
+            args.disp_threshold, args.num_consistent)
+    ply_paths = ut.get_fusion_plys(dense_folder)
+    urls = ut.handle_plys(ply_paths, dense_folder, ply_folder, args)
+    print('Sketchfab url {}'.format(urls))
+    return urls
 
 
 def main(args):

--- a/scripts/test_and_fuse.py
+++ b/scripts/test_and_fuse.py
@@ -14,13 +14,15 @@ on the file system.
 def test_and_fuse(args, dense_folder, ply_folder):
     if args.no_test is not True:
         ut.test(dense_folder, args.ckpt_step, args.model_dir)
-    ut.clear_old_points(dense_folder)
-    ut.fuse(dense_folder, args.fusibile_path, args.prob_threshold,
-            args.disp_threshold, args.num_consistent)
-    ply_paths = ut.get_fusion_plys(dense_folder)
-    urls = ut.handle_plys(ply_paths, dense_folder, ply_folder, args)
-    print('Sketchfab url {}'.format(urls))
-    return urls
+        return None
+    if args.test_only is not True:
+        ut.clear_old_points(dense_folder)
+        ut.fuse(dense_folder, args.fusibile_path, args.prob_threshold,
+                args.disp_threshold, args.num_consistent)
+        ply_paths = ut.get_fusion_plys(dense_folder)
+        urls = ut.handle_plys(ply_paths, dense_folder, ply_folder, args)
+        print('Sketchfab url {}'.format(urls))
+        return urls
 
 
 def main(args):
@@ -63,5 +65,7 @@ if __name__ == '__main__':
     parser.add_argument('--num_consistent', type=float, default='3')
     parser.add_argument('--no_test', action='store_true',
                         help='Will not run testing, but only postprocessing, if flag is set')
+    parser.add_argument('--test_only', action='store_true',
+                        help='Will only run testing, and no fusing or uploading of point clouds.')
     args = parser.parse_args()
     main(args)

--- a/scripts/test_and_fuse.py
+++ b/scripts/test_and_fuse.py
@@ -19,6 +19,7 @@ def test_and_fuse(args, dense_folder, ply_folder):
             args.disp_threshold, args.num_consistent)
     ply_paths = ut.get_fusion_plys(dense_folder)
     urls = ut.handle_plys(ply_paths, dense_folder, ply_folder, args)
+    print('Sketchfab url {}'.format(urls))
     return urls
 
 
@@ -37,8 +38,11 @@ def main(args):
     else:
         for d in os.listdir(args.test_folder_root):
             dense_folder = os.path.join(args.test_folder_root, d)
-            urls = test_and_fuse(args, dense_folder, ply_folder)
-            all_urls.append(urls)
+            try:
+                urls = test_and_fuse(args, dense_folder, ply_folder)
+                all_urls.append(urls)
+            except Exception as e:
+                print('Failed to test and fuse on dense folder {}'.format(dense_folder))
     print('Models uploaded to:', all_urls)
 
 
@@ -49,7 +53,7 @@ if __name__ == '__main__':
     parser.add_argument('--model_dir', type=str,
                         help="The directory of saved model -- see test.py")
     parser.add_argument('--test_folder_root', type=str,
-                        default='../data/7scenes/test/', help="The directory where the sessions to be tested are located")
+                        default='../data/atlas', help="The directory where the sessions to be tested are located")
     parser.add_argument('--fusibile_path', type=str,
                         default='/home/chrisheinrich/fusibile/fusibile', help="The path to the compiled fusibile executable")
     parser.add_argument('--prob_threshold', type=float, default='0.8')


### PR DESCRIPTION
This PR add the 'benchmark_depth_maps' functionality to inference.py so that a trained MVSNet model can be run and benchmarked on mvs-training data that includes GT depth. To run you set the benchmark flag to True in `inference.py` and then run the script as usual. Results will be logged to wandb if `wandb` flag is also set to True