### PR TITLE
Use OpenCV Headless, fix setup.py, pin versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def required_packages():
         'scipy==0.18',
         'matplotlib==1.5',
         'tensorflow==1.12.0',
-        'Pillow==3.1.2',
+        'Pillow==6.1.0',
         'imageio==2.5.0',
         'wandb==0.8.4',
     ]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ def required_packages():
         'Pillow==3.1.2',
         'imageio==2.5.0',
         'wandb==0.8.4',
+        'tensorflow==1.12.0',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ VERSION='0.1.0'
 
 def required_packages():
     PACKAGES = [
-        'progressbar2>=3.0',
-        'numpy>=1.13',
+        'progressbar2==3.0',
+        'numpy==1.13',
         'opencv-python-headless==4.1.0.25',
-        'scikit-learn>=0.18',
-        'scipy>=0.18',
-        'matplotlib>=1.5',
-        'Pillow>=3.1.2',
-        'imageio',
-        'wandb',
+        'scikit-learn==0.18',
+        'scipy==0.18',
+        'matplotlib==1.5',
+        'Pillow==3.1.2',
+        'imageio==2.5.0',
+        'wandb==0.8.4',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ def required_packages():
         'scikit-learn==0.18',
         'scipy==0.18',
         'matplotlib==1.5',
+        'tensorflow==1.12.0',
         'Pillow==3.1.2',
         'imageio==2.5.0',
         'wandb==0.8.4',
-        'tensorflow==1.12.0',
     ]
     return PACKAGES
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 # Package Metadata
 NAME='MVSNet'
-VERSION='0.1.0'
+VERSION='0.1.1'
 
 def required_packages():
     PACKAGES = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ VERSION='0.1.0'
 def required_packages():
     PACKAGES = [
         'progressbar2==3.0.1',
-        'numpy==1.13',
+        'numpy==1.13.3',
         'opencv-python-headless==4.1.0.25',
         'scikit-learn==0.18',
         'scipy==0.18',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ VERSION='0.1.0'
 def required_packages():
     PACKAGES = [
         'progressbar2==3.0.1',
-        'numpy==1.13.3',
+        'numpy==1.16.2',
         'opencv-python-headless==4.1.0.25',
         'scikit-learn==0.18',
         'scipy==0.18',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def required_packages():
     PACKAGES = [
         'progressbar2>=3.0',
         'numpy>=1.13',
-        'opencv-python>=3.2',
+        'opencv-python-headless==4.1.0.25',
         'scikit-learn>=0.18',
         'scipy>=0.18',
         'matplotlib>=1.5',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION='0.1.0'
 
 def required_packages():
     PACKAGES = [
-        'progressbar2==3.0',
+        'progressbar2==3.0.1',
         'numpy==1.13',
         'opencv-python-headless==4.1.0.25',
         'scikit-learn==0.18',


### PR DESCRIPTION
to test this, I ran the following 

```
virtualenv .venv
source .venv/bin/activate
pip install git+https://github.com/ubiquity6/MVSNet@andrew/opencv-headless
python -m mvsnet.inference --input_dir ~/dtu_scan_34_lighting_3/
```
and got 
```
INFO:mvsnet-inference:Computing depth maps with MVSNet. Using input width x height = 512 x 384.
INFO:mvsnet-inference:Running inference on /Users/andrew/dtu_scan_34_lighting_3/ and writing output to /Users/andrew/dtu_scan_34_lighting_3/depths_mvsnet
test
INFO:ClusterGenerator: There are 49 clusters
INFO:ClusterGenerator: 49 clusters will be used for testing
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:2D Unet with base filter 8
INFO:mvsnet-networks:3D RegNet with base filter 8
2019-07-09 16:46:04.451699: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
2019-07-09 16:46:44.568559: I depth inference 0/49 finished. Image index 28. (35.350 sec/step)
2019-07-09 16:46:55.659270: I depth inference 1/49 finished. Image index 29. (11.038 sec/step)
....
```

this will almost certainly lead to issues when integrating with ubiquity, but this will stabilize this package