### PR TITLE
add funcsigs transitive dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def required_packages():
         'scipy==0.18',
         'matplotlib==1.5',
         'tensorflow==1.12.0',
+        'funcsigs==1.0.2',
         'Pillow==6.1.0',
         'imageio==2.5.0',
         'wandb==0.8.4',


### PR DESCRIPTION
for some versions of python (including py 2.7) `funcsigs` is a transitive dep of `tensorflow` 

this should make installation successful 