### PR TITLE
Enables batch size for mvsnet

### DIFF
--- a/mvsnet/homography_warping.py
+++ b/mvsnet/homography_warping.py
@@ -24,25 +24,12 @@ def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval
 
         # depth 
         depth_num = tf.reshape(tf.cast(depth_num, 'int32'), [])
-        #depth = depth_start[batch_index] + tf.cast(tf.range(depth_num), tf.float32) * depth_interval[batch_index]
-        #print('Depth in get_homographies {}'.format(depth))
-        # preparation
-        #depth = tf.reshape(tf.tile(tf.cast(tf.range(depth_num), tf.float32),[batch_size] ), [batch_size, depth_num])
         sample = tf.ones((1,10)) * tf.reshape(depth_interval, [batch_size, 1])
         depth = tf.reshape(tf.cast(tf.range(depth_num), tf.float32), [1,depth_num]) * tf.reshape(depth_interval, [batch_size, 1])
-        # depth now has shape [batch_size, depth_num]
-        #depth_interval = tf.reshape(depth_interval, [1, batch_size])
         depth_start = tf.transpose(tf.reshape(tf.tile(depth_start,[depth_num] ), [depth_num, batch_size]))
         depth = depth + depth_start
-        print('Shape of depth start {}'.format(tf.shape(depth_start)))
-        #print('Depth start {}'.format(depth_start))
-        print('Depth interval {}'.format(depth_interval))
-        print('Sample {}'.format(sample))
-
-
-
         num_depth = tf.shape(depth)[1]
-        print('Shape of depth {}'.format(tf.shape(depth)))
+
         K_left_inv = tf.matrix_inverse(tf.squeeze(K_left, axis=1))
         R_left_trans = tf.transpose(tf.squeeze(R_left, axis=1), perm=[0, 2, 1])
         R_right_trans = tf.transpose(tf.squeeze(R_right, axis=1), perm=[0, 2, 1])
@@ -55,9 +42,6 @@ def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval
 
         # compute
         # Correctly gets the batch size from the camera
-        
-        print('Batch size in get_homographies {}'.format(batch_size))
-        #batch_size = 1
         temp_vec = tf.matmul(c_relative, fronto_direction)
         depth_mat = tf.tile(tf.reshape(depth, [batch_size, num_depth, 1, 1]), [1, 1, 3, 3])
 
@@ -264,10 +248,8 @@ def tf_transform_homography(input_image, homography):
     homography_linear = tf.slice(homography, begin=[0, 0], size=[-1, 8])
     homography_linear_div = tf.tile(tf.slice(homography, begin=[0, 8], size=[-1, 1]), [1, 8])
     homography_linear = tf.div(homography_linear, homography_linear_div)
-    # TODO: uncomment lines below
     warped_image = tf.contrib.image.transform(
         input_image, homography_linear, interpolation='BILINEAR')
     return warped_image
-    #return input_image
 
 

--- a/mvsnet/homography_warping.py
+++ b/mvsnet/homography_warping.py
@@ -7,7 +7,11 @@ Differentiable homography related.
 import tensorflow as tf
 import numpy as np
 
-def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval):
+def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval, batch_index = 0):
+    """
+    Args:
+        batch_index: The index along batch dimension in range [0,batch_size -1]
+    """
     with tf.name_scope('get_homographies'):
         # cameras (K, R, t)
         R_left = tf.slice(left_cam, [0, 0, 0, 0], [-1, 1, 3, 3])
@@ -19,7 +23,7 @@ def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval
 
         # depth 
         depth_num = tf.reshape(tf.cast(depth_num, 'int32'), [])
-        depth = depth_start + tf.cast(tf.range(depth_num), tf.float32) * depth_interval
+        depth = depth_start[batch_index] + tf.cast(tf.range(depth_num), tf.float32) * depth_interval[batch_index]
         # preparation
         num_depth = tf.shape(depth)[0]
         K_left_inv = tf.matrix_inverse(tf.squeeze(K_left, axis=1))
@@ -33,7 +37,8 @@ def get_homographies(left_cam, right_cam, depth_num, depth_start, depth_interval
         c_relative = tf.subtract(c_right, c_left)        
 
         # compute
-        batch_size = tf.shape(R_left)[0]
+        #batch_size = tf.shape(R_left)[0]
+        batch_size = 1
         temp_vec = tf.matmul(c_relative, fronto_direction)
         depth_mat = tf.tile(tf.reshape(depth, [batch_size, num_depth, 1, 1]), [1, 1, 3, 3])
 

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -8,9 +8,7 @@ import os
 import time
 import sys
 import tensorflow as tf
-import tensorflow.contrib.eager as tfe
 import numpy as np
-#tf.enable_eager_execution()
 import mvsnet.utils as mu
 import mvsnet.predictlib as pl
 
@@ -88,11 +86,6 @@ def compute_depth_maps(input_dir, **kwargs):
     mvs_iterator, sample_size = pl.setup_data_iterator(input_dir)
     scaled_images, full_images, scaled_cams, full_cams, image_index = mvs_iterator.get_next()
 
-    print('Scaled images shape {}'.format(tf.shape(scaled_images)))
-    print('Full images shape {}'.format(tf.shape(full_images)))
-    print('Full cams shape {}'.format(tf.shape(full_cams)))
-    print('Image index shape {}'.format(tf.shape(image_index)))
-
     depth_start, depth_end, depth_interval, depth_num = pl.set_shapes(
         scaled_images, full_images, scaled_cams, full_cams)
 
@@ -121,17 +114,9 @@ def compute_depth_maps(input_dir, **kwargs):
             except tf.errors.OutOfRangeError:
                 logger.info("all dense finished")  # ==> "End of dataset"
                 break
-            print('Out index')
             logger.info('Depth inference {}/{} finished. ({:.3f} sec/step)'.format(step*FLAGS.batch_size, sample_size, time.time() - start_time))
-            print('Shape of prob map out {}'.format(out_prob_map.shape))
-            print('Shape of out_index {}'.format(out_index.shape))
-            print('Shape of out_images {}'.format(out_images.shape))
-            print('Shape of out_cams {}'.format(out_cams.shape))
-            pl.write_output_batch(output_dir, out_depth_map, out_prob_map, out_images,
+            pl.write_output(output_dir, out_depth_map, out_prob_map, out_images,
                             out_cams, out_full_cams, out_full_images, out_index, out_residual_depth_map)
-            
-            #pl.write_output(output_dir, depth_map, prob_map, scaled_images, scaled_cams, full_cams, full_images, image_index, residual_depth_map)
-
 
 def main(_):  # pylint: disable=unused-argument
     """

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -39,7 +39,7 @@ tf.app.flags.DEFINE_float('interval_scale', 1.0,
                           """Downsample scale for building cost volume (D).""")
 tf.app.flags.DEFINE_float('base_image_size', 8,
                           """Base image size""")
-tf.app.flags.DEFINE_integer('batch_size', 1,
+tf.app.flags.DEFINE_integer('batch_size', 2,
                             """Testing batch size.""")
 tf.app.flags.DEFINE_bool('adaptive_scaling', True,
                          """Let image size to fit the network, including 'scaling', 'cropping'""")

--- a/mvsnet/inference.py
+++ b/mvsnet/inference.py
@@ -40,7 +40,7 @@ tf.app.flags.DEFINE_float('interval_scale', 1.0,
                           """Downsample scale for building cost volume (D).""")
 tf.app.flags.DEFINE_float('base_image_size', 8,
                           """Base image size""")
-tf.app.flags.DEFINE_integer('batch_size', 2,
+tf.app.flags.DEFINE_integer('batch_size', 1,
                             """Testing batch size.""")
 tf.app.flags.DEFINE_bool('adaptive_scaling', True,
                          """Let image size to fit the network, including 'scaling', 'cropping'""")

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -263,6 +263,8 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
 
     view_features = []
     for view in range(1, FLAGS.view_num):
+        ## It looks like, as written, the feature extractor network doesn't support the batch size 
+        # dimension, since they squeeze out only the first element
         view_image = tf.squeeze(
             tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
         view_tower = UNetDS2GN({'data': view_image}, trainable=trainable,
@@ -288,8 +290,10 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
     with tf.name_scope('cost_volume_homography'):
         depth_costs = []
 
+        # Costs are computed at each depth, and across each view
         for d in range(depth_num):
             # compute cost (standard deviation feature)
+            # This looks like  a single pass algorithm for standard deviation calculation (CH)
             ave_feature = tf.Variable(tf.zeros(
                 [FLAGS.batch_size, feature_h, feature_w, feature_c]),
                 name='ave', trainable=False, collections=[tf.GraphKeys.LOCAL_VARIABLES])

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -17,7 +17,36 @@ logger = setup_logger('mvsnet.cnn_wrapper.model')
 FLAGS = tf.app.flags.FLAGS
 
 
-def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=4):
+def get_probability_map(cv_batch, depth_map_batch, depth_start_batch, depth_interval_batch, inverse_depth = False, num_buckets=4):
+    """ Gets the probability maps for depth predictions, slice by slice if batch_size > 1. See get_probability_map_slice for more info """
+    shape = tf.shape(depth_map_batch)
+    batch_size = shape[0]
+    height = shape[1]
+    width = shape[2]
+    depth_num = tf.shape(cv_batch)[1]
+    prob_map_slices = []
+    for i in range(FLAGS.batch_size):
+        cv = cv_batch[i]
+        depth_map = depth_map_batch[i]
+        cv = tf.reshape(cv, [1, depth_num, height, width ])
+        depth_map = tf.reshape(depth_map, [1, height, width, 1 ])
+        print('Depth map batch shape {}'.format(tf.shape(depth_map_batch)))
+        print('CV batch shape {}'.format(tf.shape(cv_batch)))
+        print('Depth map slice shape {}'.format(tf.shape(depth_map)))
+        print('CV map slice shape {}'.format(tf.shape(cv)))
+        depth_start = depth_start_batch[i]
+        depth_interval = depth_interval_batch[i]
+        prob_map = get_probability_map_slice(cv, depth_map, depth_start, depth_interval, inverse_depth, num_buckets)
+        prob_map_slices.append(prob_map)
+    
+    prob_map = tf.concat(prob_map_slices, axis=0)
+    return prob_map
+
+
+
+
+
+def get_probability_map_slice(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=4):
     """ get probability map from cost volume 
     The probability map is computed by summing the probabilities of the four depth slices int he cost volume that are closest
     to the predicted depth ~ this is a simple measure of confidence that works well for downstream tasks like fusion.
@@ -113,6 +142,129 @@ def get_probability_map(cv, depth_map, depth_start, depth_interval, inverse_dept
         prob_map_left1 = tf.gather_nd(cv, voxel_coordinates_left1)
         prob_map_right1 = tf.gather_nd(cv, voxel_coordinates_right1)
         prob_map += prob_map_left1 + prob_map_right1
+    
+    prob_map = tf.reshape(prob_map, [batch_size, height, width, 1])
+
+    return prob_map
+
+
+def get_probability_map_batch(cv, depth_map, depth_start, depth_interval, inverse_depth = False, num_buckets=4):
+
+    def _repeat_(x, num_repeats):
+        x = tf.reshape(x, [-1])
+        ones = tf.ones((1, num_repeats), dtype='int32')
+        x = tf.reshape(x, shape=(-1, 1))
+        x = tf.matmul(x, ones)
+        return tf.reshape(x, [-1])
+
+    shape = tf.shape(depth_map)
+    batch_size = shape[0]
+    print('Batch size in get prob map {}'.format(batch_size))
+    print('Shape of cost volume {}'.format(tf.shape(cv)))
+    height = shape[1]
+    width = shape[2]
+    depth_num = tf.shape(cv)[1]
+    # dynamic gpu params
+
+    # byx coordinate, batched & flattened
+    b_coordinates = tf.range(batch_size)
+    print('B coordinates original shape {}'.format(tf.shape(b_coordinates)))
+    y_coordinates = tf.range(height)
+    x_coordinates = tf.range(width)
+    b_coordinates, y_coordinates, x_coordinates = tf.meshgrid(
+        b_coordinates, y_coordinates, x_coordinates)
+    print('B coordinates meshgrid shape {}'.format(tf.shape(b_coordinates)))
+    #b_coordinates = _repeat_(b_coordinates, batch_size)
+   #y_coordinates = _repeat_(y_coordinates, batch_size)
+    #x_coordinates = _repeat_(x_coordinates, batch_size)
+    b_coordinates = _repeat_(b_coordinates, 1)
+    y_coordinates = _repeat_(y_coordinates, 1)
+    x_coordinates = _repeat_(x_coordinates, 1)
+    print('B coordinates repeated shape {}'.format(tf.shape(b_coordinates)))
+
+    if inverse_depth:
+        depth_end = depth_start + \
+            (tf.cast(depth_num, tf.float32) - 1) * depth_interval
+        inv_depth_start = tf.reshape(tf.div(1.0, depth_start), [])
+        inv_depth_end = tf.reshape(tf.div(1.0, depth_end), [])
+        inv_depth = tf.lin_space(inv_depth_start, inv_depth_end, depth_num)
+        depth_samples = tf.div(1.0, inv_depth)
+        # Here we compute the depth bucket indices to be used for probability averaging
+        # Since we are using inverse depth, we compute them in inverse depth space
+        inv_depth_interval = tf.div(
+            (inv_depth_start - inv_depth_end), tf.cast(depth_num, tf.float32) - 1.0)
+        inv_depth_data = tf.div(1.0, depth_map)
+        inv_depth_data = tf.div(inv_depth_data - inv_depth_end, inv_depth_interval)
+        inv_depth_data = tf.reshape(inv_depth_data,[-1])
+        # We need to linearly invert the index to get the correct index in depth space
+        d_coordinates_left0 = depth_num - tf.cast(tf.ceil(inv_depth_data), 'int32') - 1
+        d_coordinates_left0 = tf.clip_by_value(d_coordinates_left0,0, depth_num-1)
+        d_coordinates1_right0 = depth_num - \
+            tf.cast(tf.floor(inv_depth_data), 'int32') - 1
+        d_coordinates1_right0 = tf.clip_by_value(
+            d_coordinates1_right0, 0, depth_num-1)
+        d_coordinates_left1 = tf.clip_by_value(
+            d_coordinates_left0 - 1, 0, depth_num - 1)
+        d_coordinates1_right1 = tf.clip_by_value(
+            d_coordinates1_right0 + 1, 0, depth_num - 1)
+
+    else:
+        # d coordinate (floored and ceiled), batched & flattened
+        print('Shape of depth map {}'.format(tf.shape(depth_map)))
+        # We need to subtract the starting point and divide by the depth interval for the depth map
+        # but in order to do so, we need to broadcast depth_start and depth_interval to tensors of the correct shape
+        # to apply the mathematical operation
+        #shifted_depth = (depth_map - depth_start) / depth_interval
+        inv_depth_interval = tf.div(1.0, depth_interval)
+        inv_depth_interval = tf.linalg.diag(inv_depth_interval)
+        start_tensor = tf.ones((batch_size, height, width, 1))
+        depth_start_mat = tf.linalg.diag(depth_start)
+        start_tensor = tf.linalg.tensordot(depth_start_mat, start_tensor, [[1],[0]])
+
+        shifted_depth = depth_map - start_tensor
+        shifted_depth = tf.linalg.tensordot(inv_depth_interval,shifted_depth, [[1],[0]])
+
+        #print('First component of start tensor {}'.format(start_tensor[0]))
+        
+        print('Shape of inv depth interval {}'.format(tf.shape(inv_depth_interval)))
+        print('Inv depth {}'.format(inv_depth_interval))
+
+
+        print('Shape of depth start {} and depth interval {}'.format(tf.shape(depth_start),tf.shape(depth_interval)))
+        print('Shape of shifted depth map {}'.format(tf.shape(shifted_depth)))
+        #d_coordinates = tf.reshape(shifted_depth[:,:,:,0], [-1])
+        d_coordinates = tf.reshape(shifted_depth, [-1])
+        print('Shape of d coordinates {}'.format(tf.shape(d_coordinates)))
+        d_coordinates_left0 = tf.clip_by_value(
+            tf.cast(tf.floor(d_coordinates), 'int32'), 0, depth_num - 1)
+        d_coordinates_left1 = tf.clip_by_value(
+            d_coordinates_left0 - 1, 0, depth_num - 1)
+        d_coordinates1_right0 = tf.clip_by_value(
+            tf.cast(tf.ceil(d_coordinates), 'int32'), 0, depth_num - 1)
+        d_coordinates1_right1 = tf.clip_by_value(
+            d_coordinates1_right0 + 1, 0, depth_num - 1)
+
+    # voxel coordinates
+    voxel_coordinates_left0 = tf.stack(
+        [b_coordinates, d_coordinates_left0, y_coordinates, x_coordinates], axis=1)
+    voxel_coordinates_right0 = tf.stack(
+        [b_coordinates, d_coordinates1_right0, y_coordinates, x_coordinates], axis=1)
+    # get probability image by gathering and interpolation
+    prob_map_left0 = tf.gather_nd(cv, voxel_coordinates_left0)
+    prob_map_right0 = tf.gather_nd(cv, voxel_coordinates_right0)
+    prob_map = prob_map_left0 + prob_map_right0 
+
+    if num_buckets == 4:
+        # If num_buckets = 4 then we also add the probability in another bucket to left and right
+        voxel_coordinates_right1 = tf.stack(
+            [b_coordinates, d_coordinates1_right1, y_coordinates, x_coordinates], axis=1)
+        voxel_coordinates_left1 = tf.stack(
+            [b_coordinates, d_coordinates_left1, y_coordinates, x_coordinates], axis=1)
+        prob_map_left1 = tf.gather_nd(cv, voxel_coordinates_left1)
+        prob_map_right1 = tf.gather_nd(cv, voxel_coordinates_right1)
+        prob_map += prob_map_left1 + prob_map_right1
+
+    print('Prob map shape {}'.format(tf.shape(prob_map)))
     
     prob_map = tf.reshape(prob_map, [batch_size, height, width, 1])
 
@@ -270,6 +422,7 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
         view_tower = UNetDS2GN({'data': view_image}, trainable=trainable,
                                training=training, mode=network_mode, reuse=True)
         view_features.append(view_tower.get_output())
+        print('View_image shape {}'.format(tf.shape(view_image)))
     view_features = tf.stack(view_features, axis=0)
 
     # get all homographies
@@ -284,6 +437,9 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
             homographies = get_homographies(ref_cam, view_cam, depth_num=depth_num,
                                             depth_start=depth_start, depth_interval=depth_interval)
         view_homographies.append(homographies)
+    print('First homography shape {}'.format(tf.shape(view_homographies[0])))
+    print('First homography for batch 1 {}'.format(view_homographies[0][0,0,:,:]))
+    print('First homography for batch 2 {}'.format(view_homographies[0][1,0,:,:]))
     view_homographies = tf.stack(view_homographies, axis=0)
 
     # build cost volume by differentialble homography

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -398,8 +398,6 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, network_
 
     view_features = []
     for view in range(1, FLAGS.view_num):
-        ## It looks like, as written, the feature extractor network doesn't support the batch size 
-        # dimension, since they squeeze out only the first element
         view_image = tf.squeeze(
             tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
         view_tower = UNetDS2GN({'data': view_image}, trainable=trainable,

--- a/mvsnet/predictlib.py
+++ b/mvsnet/predictlib.py
@@ -10,7 +10,6 @@ import numpy as np
 import imageio
 import cv2
 import tensorflow as tf
-import tensorflow.contrib.eager as tfe
 from mvsnet.loss import *
 from mvsnet.preprocess import *
 from mvsnet.model import inference_mem, depth_refine, inference_winner_take_all


### PR DESCRIPTION
This PR updates the mvsnet code base so that it works with batch size > 1. The original mvsnet codebase we inherited only worked with batch_size = 1, although the batch size parameter was woven throughout the codebase, so it was unclear if it just never worked or if they abandoned it somehow. Anyway, this pr fixed some issues in parts of their code to get it to work again. 

Using a batch size > 1 on CPU does not seem to speed up inference, but it should speed up the time per frame on GPU since gpu architecture is designed for this. 